### PR TITLE
Adding mulitple-valued ENV variables option to mod_auth_mellon

### DIFF
--- a/README
+++ b/README
@@ -232,6 +232,13 @@ MellonPostCount 100
         # Default. None set.
         MellonSetEnvNoPrefix "DISPLAY_NAME" "displayName"
 
+        # MellonMergeEnvVars merges multiple values of environement variables
+        # set using MellonSetEnv into single variable:
+        # ie: MYENV_VAR => val1;val2;val3 instead of default behaviour of:
+        #     MYENV_VAR_0 => val1, MYENV_VAR_1 => val2 ... etc.
+        # Default: MellonMergeEnvVars Off
+        MellonMergeEnvVars On
+
         # If MellonSessionDump is set, then the SAML session will be
         # available in the MELLON_SESSION environment variable
         MellonSessionDump Off
@@ -590,6 +597,15 @@ MELLON_<name>, and once named <MELLON_<name>_0.
 In the case of multivalued attributes MELLON_<name> will contain the first
 value.
 
+NOTE: 
+
+if MellonMergeEnvVars is set to On multiple values of attributes 
+will be stored in single environement variable, separated by ";" 
+
+MELLON_<name> -> "value1;value2;value3[;valueX]"
+
+and variables MELLON_<name>_0, MELLON_<name>_1, MELLON_<name>_2 will 
+not be created.
 
 The following code is a simple php-script which prints out all the
 variables:

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -175,6 +175,7 @@ typedef struct am_dir_cfg_rec {
 
     const char *varname;
     int secure;
+    int merge_env_vars;
     const char *cookie_domain;
     const char *cookie_path;
     apr_array_header_t *cond;

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -70,6 +70,12 @@ static const apr_size_t post_size = 1024 * 1024 * 1024;
  */
 static const int post_count = 100;
 
+/* whether to merge env. vars or not
+ * the MellonMergeEnvVars configuration directive if you change this.
+ */
+static const int default_merge_env_vars = -1;
+
+
 /* This function handles configuration directives which set a 
  * multivalued string slot in the module configuration (the destination
  * strucure is a hash).
@@ -1218,6 +1224,13 @@ const command_rec auth_mellon_commands[] = {
         OR_AUTHCFG,
         "Whether we should replay POST requests that trigger authentication. Default is off."
         ),
+    AP_INIT_FLAG(
+        "MellonMergeEnvVars",
+        ap_set_flag_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, merge_env_vars),
+        OR_AUTHCFG,
+        "Whether to merge environement variables multi-values or not. Default is off."
+        ),
     {NULL}
 };
 
@@ -1273,6 +1286,7 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
 
     dir->varname = default_cookie_name;
     dir->secure = default_secure_cookie;
+    dir->merge_env_vars = default_merge_env_vars;
     dir->cond = apr_array_make(p, 0, sizeof(am_cond_t));
     dir->cookie_domain = NULL;
     dir->cookie_path = NULL;
@@ -1392,6 +1406,10 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
     new_cfg->secure = (add_cfg->secure != default_secure_cookie ?
                         add_cfg->secure :
                         base_cfg->secure);
+
+    new_cfg->merge_env_vars = (add_cfg->merge_env_vars != default_merge_env_vars ?
+                               add_cfg->merge_env_vars :
+                               base_cfg->merge_env_vars);
 
     new_cfg->cookie_domain = (add_cfg->cookie_domain != NULL ?
                         add_cfg->cookie_domain :


### PR DESCRIPTION
In our  SSO (MS ADFS) environment we perform authorization most of the time passing IDP attributes to applications as apache ENV variables. Current mod_auth_mellon version sets these variables as single-value suffixing variable name with digits (VAR_0 = val1 , VAR_1 = val2 .. etc) which is not very practical for the above mentioned purpose .... 
Proposed patch allows - optionally - to set  multi-valued variables (VAR = val1;val2; .. etc) making mod_auth_mellon act same way the shibboleth apache module does:
 https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPAttributeAccess

Please consider including proposed patch in future mod_auth_mellon releases.

Jarek
