### PR TITLE
Replace newly-added apr_uintptr_t with apr_size_t, for apr < 1.4.0

### DIFF
--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -244,7 +244,7 @@ typedef struct am_dir_cfg_rec {
 } am_dir_cfg_rec;
 
 typedef struct am_cache_storage_t {
-    apr_uintptr_t ptr;
+    apr_size_t ptr;
 } am_cache_storage_t;
 
 typedef struct am_cache_env_t {


### PR DESCRIPTION
As per e6f60211; apr_uintptr_t was added in apr 1.4.0.  Switching to
apt_size_t restores compatibility with earlier versions of apr.

Signed-off-by: Alex Vandiver <alex@chmrr.net>