### PR TITLE
Adding MellonEnvVarsIndexStart functionality.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+
+
+* Add option MellonEnvVarsIndexStart to specify if environment variables
+  for multi-valued attributes should start indexing with 0 (default) or
+  with 1.
+
 Version 0.10.0
 ---------------------------------------------------------------------------
 

--- a/README
+++ b/README
@@ -239,6 +239,12 @@ MellonPostCount 100
         # Default: MellonMergeEnvVars Off
         MellonMergeEnvVars On
 
+        # MellonEnvVarsIndexStart specifies if environement variables for
+        # multi-valued attributes should start indexing from 0 or 1
+        # The syntax is 'MellonEnvVarsIndexStart <0|1>'.
+        # Default: MellonEnvVarsIndexStart 0
+        MellonEnvVarsIndexStart 1
+
         # If MellonSessionDump is set, then the SAML session will be
         # available in the MELLON_SESSION environment variable
         MellonSessionDump Off

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -176,6 +176,7 @@ typedef struct am_dir_cfg_rec {
     const char *varname;
     int secure;
     int merge_env_vars;
+    int env_vars_index_start;
     const char *cookie_domain;
     const char *cookie_path;
     apr_array_header_t *cond;

--- a/auth_mellon_cache.c
+++ b/auth_mellon_cache.c
@@ -590,7 +590,11 @@ void am_cache_env_populate(request_rec *r, am_cache_entry_t *t)
 
             /* This is the first time. Create a counter for this variable. */
             count = apr_palloc(r->pool, sizeof(int));
-            *count = 0;
+            if (d->env_vars_index_start > -1) {
+                *count = d->env_vars_index_start;
+            } else {
+                *count = 0;
+            }
             apr_hash_set(counters, varname, APR_HASH_KEY_STRING, count);
 
             /* Add the variable without a suffix. */

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -75,6 +75,11 @@ static const int post_count = 100;
  */
 static const int default_merge_env_vars = -1;
 
+/* for env. vars with multiple values, the index start
+ * the MellonEnvVarsIndexStart configuration directive if you change this.
+ */
+static const int default_env_vars_index_start = -1;
+
 
 /* This function handles configuration directives which set a 
  * multivalued string slot in the module configuration (the destination
@@ -1231,6 +1236,13 @@ const command_rec auth_mellon_commands[] = {
         OR_AUTHCFG,
         "Whether to merge environement variables multi-values or not. Default is off."
         ),
+    AP_INIT_TAKE1(
+        "MellonEnvVarsIndexStart",
+        ap_set_int_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, env_vars_index_start),
+        OR_AUTHCFG,
+        "Start indexing environment variables for multivalues with 0 or 1. Default is 0."
+        ),
     {NULL}
 };
 
@@ -1287,6 +1299,7 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->varname = default_cookie_name;
     dir->secure = default_secure_cookie;
     dir->merge_env_vars = default_merge_env_vars;
+    dir->env_vars_index_start = default_env_vars_index_start;
     dir->cond = apr_array_make(p, 0, sizeof(am_cond_t));
     dir->cookie_domain = NULL;
     dir->cookie_path = NULL;
@@ -1410,6 +1423,10 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
     new_cfg->merge_env_vars = (add_cfg->merge_env_vars != default_merge_env_vars ?
                                add_cfg->merge_env_vars :
                                base_cfg->merge_env_vars);
+
+    new_cfg->env_vars_index_start = (add_cfg->env_vars_index_start != default_env_vars_index_start ?
+                               add_cfg->env_vars_index_start :
+                               base_cfg->env_vars_index_start);
 
     new_cfg->cookie_domain = (add_cfg->cookie_domain != NULL ?
                         add_cfg->cookie_domain :


### PR DESCRIPTION
Proposal to allow starting the indexing of environment variables for multi-valued attributes at 1, addressing https://github.com/UNINETT/mod_auth_mellon/issues/24.