### PR TITLE
Adding MellonEnvVarsSetCount functionality.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,7 @@
 
+* Add option MellonEnvVarsSetCount to specify if the number of values
+  for any attribute should also be stored in environment variable
+  suffixed _N.
 
 * Add option MellonEnvVarsIndexStart to specify if environment variables
   for multi-valued attributes should start indexing with 0 (default) or

--- a/README
+++ b/README
@@ -245,6 +245,16 @@ MellonPostCount 100
         # Default: MellonEnvVarsIndexStart 0
         MellonEnvVarsIndexStart 1
 
+        # MellonEnvVarsSetCount specifies if number of values for any given
+        # attribute should also be stored in variable suffixed _N.
+        # ie: if user is member of two groups, the following will be set:
+        #     MELLON__groups=group1
+        #     MELLON__groups_0=group1
+        #     MELLON__groups_1=group2
+        #     MELLON__groups_N=2
+        # Default: MellonEnvVarsIndexStart Off
+        MellonEnvVarsIndexStart On
+
         # If MellonSessionDump is set, then the SAML session will be
         # available in the MELLON_SESSION environment variable
         MellonSessionDump Off

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -177,6 +177,7 @@ typedef struct am_dir_cfg_rec {
     int secure;
     int merge_env_vars;
     int env_vars_index_start;
+    int env_vars_count_in_n;
     const char *cookie_domain;
     const char *cookie_path;
     apr_array_header_t *cond;

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -80,6 +80,11 @@ static const int default_merge_env_vars = -1;
  */
 static const int default_env_vars_index_start = -1;
 
+/* whether to also populate env. var _N with number of values
+ * the MellonEnvVarsSetCount configuration directive if you change this.
+ */
+static const int default_env_vars_count_in_n = -1;
+
 
 /* This function handles configuration directives which set a 
  * multivalued string slot in the module configuration (the destination
@@ -1243,6 +1248,13 @@ const command_rec auth_mellon_commands[] = {
         OR_AUTHCFG,
         "Start indexing environment variables for multivalues with 0 or 1. Default is 0."
         ),
+    AP_INIT_FLAG(
+        "MellonEnvVarsSetCount",
+        ap_set_flag_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, env_vars_count_in_n),
+        OR_AUTHCFG,
+        "Whether to also populate environment variable suffixed _N with number of values. Default is off."
+        ),
     {NULL}
 };
 
@@ -1300,6 +1312,7 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->secure = default_secure_cookie;
     dir->merge_env_vars = default_merge_env_vars;
     dir->env_vars_index_start = default_env_vars_index_start;
+    dir->env_vars_count_in_n = default_env_vars_count_in_n;
     dir->cond = apr_array_make(p, 0, sizeof(am_cond_t));
     dir->cookie_domain = NULL;
     dir->cookie_path = NULL;
@@ -1427,6 +1440,10 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
     new_cfg->env_vars_index_start = (add_cfg->env_vars_index_start != default_env_vars_index_start ?
                                add_cfg->env_vars_index_start :
                                base_cfg->env_vars_index_start);
+
+    new_cfg->env_vars_count_in_n = (add_cfg->env_vars_count_in_n != default_env_vars_count_in_n ?
+                               add_cfg->env_vars_count_in_n :
+                               base_cfg->env_vars_count_in_n);
 
     new_cfg->cookie_domain = (add_cfg->cookie_domain != NULL ?
                         add_cfg->cookie_domain :


### PR DESCRIPTION
Proposing patch for issue https://github.com/UNINETT/mod_auth_mellon/issues/26.

As currently proposed, setting ```MellonEnvVarsSetCount On``` will populate ```MELLON__groups_N=3```. Alternatively, we could have the option take string instead of boolean, so that you could do ```MellonEnvVarsSetCount count``` and it would populate ```MELLON__groups_count=3```. Please let me know if you'd prefer to have the suffix configurable.

I set the value whenever new one is found. I can certainly do separate looping through ```counters``` after all values were processed but we would need to duplicate the logic about determining the environment variable prefix. Let me know if you do not like that the ```apr_table_set``` gets called multiple times for multivalued attributes.

I have reverted https://github.com/UNINETT/mod_auth_mellon/pull/25's original change to just use ```*count = 0;``` so that the counters value reflects the number of previous insertions and we can use the value without additional conditions on ```d->env_vars_index_start```. Additionally, the original code from https://github.com/UNINETT/mod_auth_mellon/pull/25 did not work nicely if you had ```MellonEnvVarsIndexStart 1``` (possibly through inheritance) set together with ```MellonMergeEnvVars On``` -- the first value would get duplicated then. Sorry about not catching it earlier and let me know if you'd like to treat this condition as a bug and moved into separate pull request / commit.