### PR TITLE
MellonMergeEnvVars can now take second optional parameter to specify the separator.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,7 @@
 
+* MellonMergeEnvVars On now accepts second optional parameter, the
+  separator to be used instead of the default ';'.
+
 * Add option MellonEnvVarsSetCount to specify if the number of values
   for any attribute should also be stored in environment variable
   suffixed _N.

--- a/README
+++ b/README
@@ -236,8 +236,11 @@ MellonPostCount 100
         # set using MellonSetEnv into single variable:
         # ie: MYENV_VAR => val1;val2;val3 instead of default behaviour of:
         #     MYENV_VAR_0 => val1, MYENV_VAR_1 => val2 ... etc.
+        # Second optional parameter specifies the separator, to override the
+        # default semicolon.
         # Default: MellonMergeEnvVars Off
         MellonMergeEnvVars On
+        MellonMergeEnvVars On ":"
 
         # MellonEnvVarsIndexStart specifies if environement variables for
         # multi-valued attributes should start indexing from 0 or 1

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -175,7 +175,7 @@ typedef struct am_dir_cfg_rec {
 
     const char *varname;
     int secure;
-    int merge_env_vars;
+    const char *merge_env_vars;
     int env_vars_index_start;
     int env_vars_count_in_n;
     const char *cookie_domain;

--- a/auth_mellon_cache.c
+++ b/auth_mellon_cache.c
@@ -597,7 +597,11 @@ void am_cache_env_populate(request_rec *r, am_cache_entry_t *t)
             apr_table_set(r->subprocess_env,prefixed_varname,value);
         }
 
-        if (d->merge_env_vars != 1) {
+        /* Check if merging of environment variables is disabled.
+         * This is either if it is NULL (default value if not configured
+         * by user) or an empty string (if specifically disabled by the user).
+         * /
+        if (d->merge_env_vars == NULL || *d->merge_env_vars == '\0') {
          
             /* Add the variable with a suffix indicating how many times it has
              * been added before.
@@ -612,7 +616,7 @@ void am_cache_env_populate(request_rec *r, am_cache_entry_t *t)
         } else if (*count > 0) {
 
             /*
-             * Merge multiple values, separating with ";" 
+             * Merge multiple values, separating by default with ";"
              * this makes auth_mellon work same way mod_shib is:
              * https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPAttributeAccess
              */
@@ -620,7 +624,7 @@ void am_cache_env_populate(request_rec *r, am_cache_entry_t *t)
                            prefixed_varname,
                            apr_pstrcat(r->pool, 
                                        apr_table_get(r->subprocess_env,prefixed_varname),
-                                       ";", value, NULL));
+                                       d->merge_env_vars, value, NULL));
         }
           
         /* Increase the count. */


### PR DESCRIPTION
Addressing issue https://github.com/UNINETT/mod_auth_mellon/issues/27.

Note that with the proposed code, if you have

```
<Location />
    MellonMergeEnvVars On ":"
</Location>
<Location /a>
    MellonMergeEnvVars Off
</Location>
<Location /a/b>
    MellonMergeEnvVars On
</Location>
```

the separator for ```/a/b``` will be semicolon, not colon. Hopefully that's what people who use the existing functionality will expect.

Alternatively we could say that noone will likely use alphanumeric separator anyway, so that ```MellonMergeEnvVars``` could take just one argument, the separator string, with two special values, ```on``` and ```off```.