### PR TITLE
Add support for SAML ECP.

### DIFF
--- a/ECP.rst
+++ b/ECP.rst
@@ -67,7 +67,7 @@ How does mod_auth_mellon recognize a request is from an ECP client?
 In Step 1. when the ECP client issues the HTTP Request to the SP it
 **MUST** include `application/vnd.paos+xml` as a mime type in the HTTP
 `Accept` header field and include an HTTP `PAOS` header specifying a
-minimum PAOS version of `urn:liberty:paos:2003-08` and an ECP service
+PAOS version of `urn:liberty:paos:2003-08` and an ECP service
 declaration of `urn:oasis:names:tc:SAML:2.0:profiles:SSO:ecp` [2]_,
 for example::
 

--- a/ECP.rst
+++ b/ECP.rst
@@ -1,0 +1,286 @@
+Guide to using ECP
+==================
+
+Introduction
+------------
+
+The **Enhanced Client or Proxy** (ECP) profile of SAML2
+
+The Enhanced Client or Proxy (ECP) Profile supports several SSO use
+cases, in particular:
+
+  * Clients with capabilities beyond those of a browser, allowing them
+    to more actively participate in IdP discovery and message flow.
+
+  * Using a proxy server, for example a WAP gateway in front of a mobile
+    device which has limited functionality.
+
+  * When other bindings are precluded (e.g. where the client does not
+    support redirects, or when auto form post is not possible without
+    Javascript, or when the artifact binding is ruled out because the
+    identity provider and service provider cannot directly communicate.
+
+An enhanced client or proxy (ECP) is a system entity that knows how to
+contact an appropriate identity provider, possibly in a
+context-dependent fashion, and also supports the Reverse SOAP (PAOS)
+binding.
+
+An example scenario enabled by ECP profile is as follows: A principal,
+wielding an ECP, uses it to either access a resource at a service
+provider, or access an identity provider such that the service
+provider and desired resource are understood or implicit. The
+principal authenticates (or has already authenticated) with the
+identity provider [1]_, which then produces an authentication assertion
+(possibly with input from the service provider). The service provider
+then consumes the assertion and subsequently establishes a security
+context for the principal. During this process, a name identifier
+might also be established between the providers for the principal,
+subject to the parameters of the interaction and the consent of the
+principal.
+
+SAML2 Profile for ECP (Section 4.2) defines these steps for an ECP
+transaction:
+
+  1. ECP issues HTTP Request to SP
+  2. SP issues <AuthnRequest> to ECP using PAOS
+  3. ECP determines IdP
+  4. ECP conveys <AuthnRequest> to IdP using SOAP
+  5. IdP identifies principal
+  6. IdP issues <Response> to ECP, targeted at SP using SOAP
+  7. ECP conveys <Response> to SP using PAOS
+  8. SP grants or denies access to principal
+
+mod_auth_mellon and ECP
+-----------------------
+
+mod_auth_mellon plays the role of the SP in an ECP transaction.
+
+mod_auth_mellon utilizes the Lasso library to provide it's SAML2
+functionality. Fully functioning SAML2 ECP support in Lasso is
+relatively new. When mod_auth_mellon is built it detects the presence
+of SAML2 ECP in Lasso and only compiles in the ECP code in
+mod_auth_mellon if it's present in Lasso.
+
+How does mod_auth_mellon recognize a request is from an ECP client?
+```````````````````````````````````````````````````````````````````
+
+In Step 1. when the ECP client issues the HTTP Request to the SP it
+**MUST** include `application/vnd.paos+xml` as a mime type in the HTTP
+`Accept` header field and include an HTTP `PAOS` header specifying a
+minimum PAOS version of `urn:liberty:paos:2003-08` and an ECP service
+declaration of `urn:oasis:names:tc:SAML:2.0:profiles:SSO:ecp` [2]_,
+for example::
+
+  Accept: text/html; application/vnd.paos+xml
+  PAOS: ver="urn:liberty:paos:2003-08";"urn:oasis:names:tc:SAML:2.0:profiles:SSO:ecp"
+
+If mod_auth_mellon sees this in the incoming request it knows the
+client is ECP aware and capable. If authentication is required
+mod_auth_mellon will initiate an ECP flow.
+
+The role of IdP's in ECP
+````````````````````````
+
+The SAML2 ECP profile states it is the ECP client which determines the
+IdP that will be used for authentication. This is in contrast to the
+Web SSO flow where the SP determines the IdP. However, the ECP
+protocol permits an SP to send the ECP client a list of IdP's it
+trusts. It is optional if the SP sends an IDPList, if it does the ECP
+client should select the IdP from the SP provided IDPList otherwise
+the ECP client is free to select any IdP it wishes.
+
+If the mellon configuration option `MellonECPSendIDPList` is true then
+mod_auth_mellon will include an IDPList when it returns a PAOS
+<AuthnRequest> to the ECP client.
+
+To build the IDPList mod_auth_mellon scans it's list of loaded IdP's
+selecting those which are ECP capable. To support ECP an IdP must
+advertise the SingleSignOn service utilizing the SOAP binding.
+
+ECP specific mod_auth_mellon configuration directives
+`````````````````````````````````````````````````````
+
+These configuration directives are specific to ECP:
+
+MellonECPSendIDPList
+  If `On` mod_auth_mellon will send an IdP list to the ECP client
+  containing only those IdP's capable of ECP flow. The ECP client
+  should select an IdP only from this list. If this option is `Off`
+  no IdP list will be sent and the ECP client is free to select any
+  IdP.
+
+Example ECP client
+``````````````````
+
+To illustrate a simple ECP client based on Lasso we'll use the Lasso
+Python binding (as opposed to pseudo code, Python is quite
+readable). All error checking and another necessary ancillary code has
+been eliminated in order to clearly illustrate only the ECP
+operations.
+
+.. code-block:: python
+
+  import lasso
+  import requests
+
+  ecp = lasso.Ecp(server)
+  session = requests.Session()
+
+  MEDIA_TYPE_PAOS = 'application/vnd.paos+xml'
+  PAOS_HEADER = 'ver="%s";"%s"' % (lasso.PAOS_HREF,lasso.ECP_HREF)
+
+  # Step 1: Request protected resource, indicate ECP capable
+  response = session.get(protected, headers={'Accept': MEDIA_TYPE_PAOS,
+                                             'PAOS': PAOS_HEADER})
+
+  # Process returned PAOS wrapped <AuthnRequest>
+  ecp.processAuthnRequestMsg(response.text)
+
+  # Post SOAP wrapped <AuthnRequest> to IdP, use Digest Auth to authenticate
+  response = session.post(ecp.msgUrl,
+                          data=ecp.msgBody,
+                          auth=requests.auth.HTTPDigestAuth(user, password)
+                          headers={'Content-Type': 'application/soap+xml'})
+
+  # Process returned SOAP wrapped <Assertion> from IdP
+  ecp.processResponseMsg(response.text)
+
+  # Post PASO wrapped <Assertion> to SP, response is protected resource
+  response = session.post(ecp.msgUrl,
+                          data=ecp.msgBody,
+                          headers={'Content-Type': 'application/vnd.paos+xml'})
+
+
+mod_auth_mellon internal ECP implementation notes
+-------------------------------------------------
+
+
+Notes on ECP vs. Web SSO flow
+`````````````````````````````
+
+Web SSO (Single Sign-On) flow is by far the most common and what
+most people are familiar with when they think of SAML. The Web SSO
+profile is designed so that browsers ignorant of SAML can perform
+SAML authentication without modification. This is accomplished with
+existing HTTP paradigms such as redirects, form posts, etc. which a
+browser will process normally yielding the desired result.
+
+ECP (Enhanced Client or Proxy) is a different SAML profile that
+also accomplishes SSO (Single Sign-On). The distinction is an ECP
+client is fully SAML aware and actively participates in the SAML
+conversation.
+
+Web SSO and ECP have very different flows, mod_auth_mellon must
+support both flows. mod_auth_mellon is a SP (Service Provider).
+
+IdP Selection Differences
+`````````````````````````
+
+With Web SSO the SP determines the IdP and redirects there.
+
+With ECP the ECP client determines the IdP, the SP has no a prori
+knowledge of the target IdP, although the SP may provide a
+suggested list of IdP's when responding to the ECP client.
+
+Since with ECP it is the ECP client which selects the IdP the set of
+IdP's loaded into mod_auth_mellon are not relevant **except** if
+`MellonECPSendIDPList` is enabled. In this case mod_auth_mellon will
+filter the set of loaded IdP's and forward those IdP's supporting
+SingleSignOn with the SOAP binding.
+
+Apache request processing pipeline
+``````````````````````````````````
+
+Apache implements a request processing pipeline composed of
+stages. An Apache extension module can participate in the pipeline
+by asking to be called at specific stages (steps) by registering a
+hook function for that stage. Final content returned to the HTTP
+client in the HTTP response is generated in the "handler", one of
+the final stages in the request processing pipeline.
+
+One of the stages in the request pipeline is determining
+authentication and authorization for protected resources. If a
+resource is protected and the authentication and authorization
+pipeline stages deny access or fail the request processing pipeline
+is aborted early, a non-success HTTP response is returned, the
+content handler is never reached.
+
+With Web SSO if authentication needs to be performed a redirect will
+be returned that redirects to a SAML endpoint (login) on our SP. This
+in turn generates the SAML <AuthnRequest> with a redirect to the
+IdP. All of this is very vanilla standard HTTP easily accommodated by
+Apache's request processing pipeline which is designed to handle these
+types of flows.
+
+ECP requires special handling
+`````````````````````````````
+
+However ECP has a very different flow. When an ECP client sends a
+request to the SP it includes a special HTTP headers indicating it is
+ECP capable. If the SP determines the resource is protected and
+authentication is needed and the client has signaled it is ECP capable
+then the SP responds successfully (200) with a SAML <AuthnRequest>
+wrapped in PAOS. *This is very different than conventional HTTP
+request processing.* Here we have a case where there is a protected
+resource that has **not** been authenticated yet the web server will
+responds with an HTTP 200 success and content! One might normally
+expect a HTTP 401 or redirect response for a protected resource when
+there is no authenticated user. *This is clearly contrary to the
+expectations of Apache's request processing pipeline.*
+
+Reaching the Apache content handler
+```````````````````````````````````
+
+In order to be able to return a successful (HTTP 200) PAOS response
+when doing the ECP we have to reach the part of Apache's request
+processing pipeline that generates the response. In Apache terminology
+this is called a (content) handler.
+
+At an early stage we detect if authentication is required. For the
+normal Web SSO profile we would redirect the client back to our login
+endpoint which will be handled by our handler in a different
+request. But for ECP the current request must proceed. We set a flag
+on the request indicating ECP authentication is required. The pipeline
+continues. When the pipeline reaches the authentication and
+authorization stages we check the ECP flag on the request, if ECP
+authentication is indicated we lie and tell the pipeline the user is
+authenticated and authorized. We do this only so we can reach the
+handler stage (otherwise because the request is for a protected
+resource the pipeline would terminate with an error). Despite our
+having forced authentication and authorization to be valid for the
+protected resource the request processing pipeline *will not return the
+protected resource* because we will subsequently intercept the request
+in our handler before the pipeline reaches the point of returning the
+protected resource.
+
+At the handler stage
+````````````````````
+
+Once our handler is invoked it has 3 possible actions to perform:
+
+  1. The request is for one of our SAML endpoints (e.g. login,
+  logout, metadata, etc.) We dispatch to the handler for the specific
+  action. We detect this case by matching the request URI to our SAML
+  endpoints. We signal to the pipeline that our hook handled the request.
+
+  2. The request is for a protected resource and needs ECP
+  authentication performed. We detect this case by examining the ECP flag
+  set on the request by an earlier hook function. The request URI is
+  for the protected resource and has nothing to do with our SAML
+  endpoints. We generate the PAOS <AuthnRequest> and respond with
+  success (200) and signal to the pipeline that our hook handled the
+  request. Note, we have not returned the protected resource, instead
+  we've returned the PAOS request.
+
+  3. The request has nothing to do with us, we decline to handle
+  it. The pipeline proceeds to the next handler.
+
+
+.. [1] The means by which a principal authenticates with an identity
+       provider is outside of the scope of SAML. Typically an ECP
+       client will utilize an HTTP authentication method when posting
+       the <AuthnRequest> SOAP message to the IdP.
+
+.. [2] Contrary to most HTTP headers the values in the PAOS header must
+       be enclosed in double quotes. A semicolon is used to separate
+       the values.

--- a/README
+++ b/README
@@ -533,6 +533,10 @@ MellonPostCount 100
         # The default is to not redirect, but rather send a
         # 401 Unautorized error.
 
+        # This option controls whether to include a list of IDP's when
+        # sending an ECP PAOS <AuthnRequest> message to an ECP client.
+        MellonECPSendIDPList Off
+
 </Location>
 
 

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -411,7 +411,8 @@ bool am_validate_paos_header(request_rec *r, const char *header);
 bool am_header_has_media_type(request_rec *r, const char *header,
                               const char *media_type);
 const char *am_get_config_langstring(apr_hash_t *h, const char *lang);
-int am_get_is_passive(request_rec *r, int *is_passive);
+int am_get_boolean_query_parameter(request_rec *r, const char *name,
+                                   int *return_value, int default_value);
 char *am_get_assertion_consumer_service_by_binding(LassoProvider *provider, const char *binding);
 
 int am_auth_mellon_user(request_rec *r);

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -335,6 +335,10 @@ static const int inherit_subject_confirmation_data_address_check = -1;
 static const int default_post_replay = 0;
 static const int inherit_post_replay = -1;
 
+/* Whether to send an ECP client a list of IdP's */
+static const int default_ecp_send_idplist = 0;
+static const int inherit_ecp_send_idplist = -1;
+
 
 void *auth_mellon_dir_config(apr_pool_t *p, char *d);
 void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add);

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -85,6 +85,7 @@
  */
 #define AM_ID_LENGTH 32
 
+#define MEDIA_TYPE_PAOS "application/vnd.paos+xml"
 
 #define am_get_srv_cfg(s) (am_srv_cfg_rec *)ap_get_module_config((s)->module_config, &auth_mellon_module)
 
@@ -414,6 +415,10 @@ const char *am_get_config_langstring(apr_hash_t *h, const char *lang);
 int am_get_boolean_query_parameter(request_rec *r, const char *name,
                                    int *return_value, int default_value);
 char *am_get_assertion_consumer_service_by_binding(LassoProvider *provider, const char *binding);
+
+#ifdef HAVE_ECP
+bool am_is_paos_request(request_rec *r);
+#endif /* HAVE_ECP */
 
 int am_auth_mellon_user(request_rec *r);
 int am_check_uid(request_rec *r);

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -85,6 +85,9 @@ static const int default_env_vars_index_start = -1;
  */
 static const int default_env_vars_count_in_n = -1;
 
+/* Whether to send an ECP client a list of IdP's */
+static const int default_ecp_send_idplist = 0;
+
 
 /* This function handles configuration directives which set a 
  * multivalued string slot in the module configuration (the destination
@@ -1303,6 +1306,13 @@ const command_rec auth_mellon_commands[] = {
         OR_AUTHCFG,
         "Whether to also populate environment variable suffixed _N with number of values. Default is off."
         ),
+    AP_INIT_FLAG(
+        "MellonECPSendIDPList",
+        ap_set_flag_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, ecp_send_idplist),
+        OR_AUTHCFG,
+        "Whether to send an ECP client a list of IdP's. Default is off."
+        ),
     {NULL}
 };
 
@@ -1401,6 +1411,8 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->subject_confirmation_data_address_check = inherit_subject_confirmation_data_address_check;
     dir->do_not_verify_logout_signature = apr_hash_make(p);
     dir->post_replay = inherit_post_replay;
+
+    dir->ecp_send_idplist = default_ecp_send_idplist;
 
     return dir;
 }
@@ -1635,6 +1647,11 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
     new_cfg->subject_confirmation_data_address_check =
         CFG_MERGE(add_cfg, base_cfg, subject_confirmation_data_address_check);
     new_cfg->post_replay = CFG_MERGE(add_cfg, base_cfg, post_replay);
+
+    new_cfg->ecp_send_idplist = (add_cfg->ecp_send_idplist != default_ecp_send_idplist ?
+                               add_cfg->ecp_send_idplist :
+                               base_cfg->ecp_send_idplist);
+
 
     return new_cfg;
 }

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -85,10 +85,6 @@ static const int default_env_vars_index_start = -1;
  */
 static const int default_env_vars_count_in_n = -1;
 
-/* Whether to send an ECP client a list of IdP's */
-static const int default_ecp_send_idplist = 0;
-
-
 /* This function handles configuration directives which set a 
  * multivalued string slot in the module configuration (the destination
  * strucure is a hash).
@@ -1412,7 +1408,7 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->do_not_verify_logout_signature = apr_hash_make(p);
     dir->post_replay = inherit_post_replay;
 
-    dir->ecp_send_idplist = default_ecp_send_idplist;
+    dir->ecp_send_idplist = inherit_ecp_send_idplist;
 
     return dir;
 }
@@ -1648,10 +1644,7 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
         CFG_MERGE(add_cfg, base_cfg, subject_confirmation_data_address_check);
     new_cfg->post_replay = CFG_MERGE(add_cfg, base_cfg, post_replay);
 
-    new_cfg->ecp_send_idplist = (add_cfg->ecp_send_idplist != default_ecp_send_idplist ?
-                               add_cfg->ecp_send_idplist :
-                               base_cfg->ecp_send_idplist);
-
+    new_cfg->ecp_send_idplist = CFG_MERGE(add_cfg, base_cfg, ecp_send_idplist);
 
     return new_cfg;
 }

--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -83,6 +83,7 @@ static const char *am_cookie_params(request_rec *r)
  */
 const char *am_cookie_get(request_rec *r)
 {
+    am_req_cfg_rec *req_cfg;
     const char *name;
     const char *value;
     const char *cookie;
@@ -96,8 +97,8 @@ const char *am_cookie_get(request_rec *r)
     }
 
     /* Check if we have added a note on the current request. */
-    value = (const char *)ap_get_module_config(r->request_config,
-                                               &auth_mellon_module);
+    req_cfg = am_get_req_cfg(r);
+    value = req_cfg->cookie_value;
     if(value != NULL) {
         return value;
     }
@@ -180,6 +181,7 @@ const char *am_cookie_get(request_rec *r)
  */
 void am_cookie_set(request_rec *r, const char *id)
 {
+    am_req_cfg_rec *req_cfg;
     const char *name;
     const char *cookie_params;
     char *cookie;
@@ -202,8 +204,8 @@ void am_cookie_set(request_rec *r, const char *id)
     /* Add a note on the current request, to allow us to retrieve this
      * cookie in the current request.
      */
-    ap_set_module_config(r->request_config, &auth_mellon_module,
-                         apr_pstrdup(r->pool, id));
+    req_cfg = am_get_req_cfg(r);
+    req_cfg->cookie_value = apr_pstrdup(r->pool, id);
 }
 
 

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -3000,7 +3000,7 @@ static int am_send_paos_authn_request(request_rec *r)
         return ret;
     }
 
-    if (dir_cfg->ecp_send_idplist) {
+    if (CFG_VALUE(dir_cfg, ecp_send_idplist)) {
         lasso_profile_set_idp_list(LASSO_PROFILE(login),
                                    am_get_idp_list(LASSO_PROFILE(login)->server,
                                                    LASSO_MD_PROTOCOL_TYPE_SINGLE_SIGN_ON,

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -2981,7 +2981,7 @@ static int am_send_paos_authn_request(request_rec *r)
         return HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    ret = am_get_is_passive(r, &is_passive);
+    ret = am_get_boolean_query_parameter(r, "IsPassive", &is_passive, FALSE);
     if (ret != OK) return ret;
 
     relay_state = am_reconstruct_url(r);
@@ -3184,7 +3184,8 @@ static int am_handle_login(request_rec *r)
         }
     }
 
-    if ((ret = am_get_is_passive(r, &is_passive)) != OK) {
+    ret = am_get_boolean_query_parameter(r, "IsPassive", &is_passive, FALSE);
+    if (ret != OK) {
         return ret;
     }
 

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -2942,8 +2942,10 @@ am_get_idp_list(const LassoServer *server, LassoMdProtocolType protocol_type, La
          entity_id = g_list_next(entity_id)) {
         idp_entry = LASSO_SAMLP2_IDP_ENTRY(lasso_samlp2_idp_entry_new());
         idp_entry->ProviderID = g_strdup(entity_id->data);
-        idp_entry->Name = NULL; /* FIXME: Where do we get this? */
-        idp_entry->Loc = NULL; /* FIXME: Where do we get this? */
+
+        /* RFE: we should have a mechanism to obtain these values */
+        idp_entry->Name = NULL; 
+        idp_entry->Loc = NULL;
 
         idp_entries = g_list_append(idp_entries, idp_entry);
     }

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -2985,7 +2985,7 @@ static int am_send_paos_authn_request(request_rec *r)
 
     assertion_consumer_service_url =
         am_get_assertion_consumer_service_by_binding(LASSO_PROVIDER(server),
-                                                     "PASO");
+                                                     "PAOS");
 
     ret = am_init_authn_request_common(r, &login,
                                        NULL, LASSO_HTTP_METHOD_PAOS, NULL,

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -2971,7 +2971,7 @@ static int am_send_paos_authn_request(request_rec *r)
     LassoLogin *login;
     const char *relay_state = NULL;
     char *assertion_consumer_service_url;
-    int is_passive;
+    int is_passive = FALSE;
 
     dir_cfg = am_get_dir_cfg(r);
 
@@ -2979,9 +2979,6 @@ static int am_send_paos_authn_request(request_rec *r)
     if(server == NULL) {
         return HTTP_INTERNAL_SERVER_ERROR;
     }
-
-    ret = am_get_boolean_query_parameter(r, "IsPassive", &is_passive, FALSE);
-    if (ret != OK) return ret;
 
     relay_state = am_reconstruct_url(r);
 
@@ -3022,7 +3019,7 @@ static int am_send_paos_authn_request(request_rec *r)
  *  request_rec *r         The request we are processing.
  *  const char *idp        The entityID of the IdP.
  *  const char *return_to  The URL we should redirect to when receiving the request.
- *  int is_passive         Whether to send a passive request.
+ *  int is_passive         The value of the IsPassive flag in <AuthnRequest>
  *
  * Returns:
  *  HTTP response code indicating success or failure.

--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -1702,7 +1702,7 @@ int am_get_boolean_query_parameter(request_rec *r, const char *name,
 
     value_str = am_extract_query_parameter(r->pool, r->args, name);
     if (value_str != NULL) {
-        ret = am_urldecode((char*)value_str);
+        ret = am_urldecode(value_str);
         if (ret != OK) {
             ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
                           "Error urldecoding \"%s\" boolean query parameter, "

--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -1577,9 +1577,6 @@ bool am_validate_paos_header(request_rec *r, const char *header)
  cleanup:
     g_strfreev(semicolon_tokens);
     return result;
-
-
-    return false;
 }
 #undef PAOS_VERSION_TOKEN
 #undef ECP_SERVICE_TOKEN

--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -1502,3 +1502,321 @@ am_get_service_url(request_rec *r, LassoProfile *profile, char *service_name)
 
     return url;
 }
+
+/* Thus function checks if an HTTP PAOS header is valid.
+ *
+ * A PAOS header must be composed of 2 values seperated by a semicolon.
+ *
+ * The first value must be a version declaration in the form ver="xxx"
+ * (note the version string must be in double quotes).
+ *
+ * The second value must be the ECP service.
+ * (note the service string must be in double quotes).
+ *
+ * Parameters:
+ *  request_rec *r         The request
+ *  const char *header     The PAOS header value
+ *
+ * Returns:
+ *   true if the PAOS header is valid, false otherwise
+ *
+ */
+#define PAOS_VERSION_TOKEN "ver=\"" LASSO_PAOS_HREF "\""
+#define ECP_SERVICE_TOKEN  "\"" LASSO_ECP_HREF "\""
+bool am_validate_paos_header(request_rec *r, const char *header)
+{
+    bool result = false;
+    char **semicolon_tokens = NULL;
+    char *token = NULL;
+    guint len;
+
+    if (header == NULL) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                     "invalid PAOS header, NULL");
+        goto cleanup;
+    }
+
+    /* Split the header on the semicolon character */
+    semicolon_tokens = g_strsplit(header, ";", 0);
+
+    /* There must be exactly two tokens after splitting */
+    len = g_strv_length(semicolon_tokens);
+    if (len != 2) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                     "invalid PAOS header, "
+                     "expected 2 tokens seperated by semicolon, header=\"%s\"",
+                     header);
+        goto cleanup;
+    }
+
+    /* Validate the first token as the PAOS version */
+    token = g_strstrip(semicolon_tokens[0]);
+    if (!g_str_equal(token, PAOS_VERSION_TOKEN)) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                     "invalid PAOS header, "
+                     "expected first token to be \"%s\", "
+                     "but found \"%s\" in header=\"%s\"",
+                     PAOS_VERSION_TOKEN, token, header);
+        goto cleanup;
+    }
+
+    /* Validate the second token as the ECP service */
+    token = g_strstrip(semicolon_tokens[1]);
+    if (!g_str_equal(token, ECP_SERVICE_TOKEN)) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                     "invalid PAOS header, "
+                     "expected second token to be \"%s\", "
+                     "but found \"%s\" in header=\"%s\"",
+                     ECP_SERVICE_TOKEN, token, header);
+        goto cleanup;
+    }
+
+    /* No problems, we're good */
+    result = true;
+
+ cleanup:
+    g_strfreev(semicolon_tokens);
+    return result;
+
+
+    return false;
+}
+#undef PAOS_VERSION_TOKEN
+#undef ECP_SERVICE_TOKEN
+
+/* This function checks if Accept header has a media type
+ *
+ * Given an Accept header value like this:
+ *
+ * "text/html,application/xhtml+xml,application/xml;q=0.9"
+ *
+ * Parse the string and find name of each media type, ignore any parameters
+ * bound to the name. Test to see if the name matches the input media_type.
+ *
+ * Parameters:
+ *  request_rec *r         The request
+ *  const char *header     The header value
+ *  const char *media_type media type header value to check (case insensitive)
+ *
+ * Returns:
+ *   true if media type is in header, false otherwise
+ */
+bool am_header_has_media_type(request_rec *r, const char *header, const char *media_type)
+{
+    bool result = false;
+    char **comma_tokens = NULL;
+    char **media_ranges = NULL;
+    char *media_range = NULL;
+
+    if (header == NULL) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                     "invalid Accept header, NULL");
+        goto cleanup;
+    }
+
+    /*
+     * Split the header into a list of media_range tokens seperated by
+     * a comma and iterate over the list.
+     */
+    comma_tokens = g_strsplit(header, ",", 0);
+    for (media_ranges = comma_tokens, media_range = *media_ranges;
+         media_range;
+         media_range = *(++media_ranges)) {
+        char **semicolon_tokens = NULL;
+        char *name = NULL;
+
+        /*
+         * Split the media_range into a name and parameters, each
+         * separated by a semicolon. The first element in the list is
+         * the media_type name, subsequent params are optional and ignored.
+         */
+        media_range = g_strstrip(media_range);
+        semicolon_tokens = g_strsplit(media_range, ";", 0);
+
+        /*
+         * Does the media_type match our required media_type?
+         * If so clean up and return success.
+         */
+        name = g_strstrip(semicolon_tokens[0]);
+        if (name && g_str_equal(name, media_type)) {
+            result = true;
+            g_strfreev(semicolon_tokens);
+            goto cleanup;
+        }
+        g_strfreev(semicolon_tokens);
+    }
+
+ cleanup:
+    g_strfreev(comma_tokens);
+    return result;
+}
+
+/*
+ * Lookup a config string in a specific language.  If lang is NULL and
+ * the config string had been defined without a language qualifier
+ * return the unqualified value.  If not found NULL is returned.
+ */
+const char *am_get_config_langstring(apr_hash_t *h, const char *lang)
+{
+    char *string;
+
+    if (lang == NULL) {
+        lang = "";
+    }
+
+    string = (char *)apr_hash_get(h, lang, APR_HASH_KEY_STRING);
+
+    return string;
+}
+
+/*
+ * Get the value of the isPassive flag.
+ *
+ * Parameters:
+ *  request_rec *r         The request
+ *  int *is_passive        The return location of the flag
+ *
+ * Returns:
+ *   OK on success, HTTP error otherwise
+ *
+ * Looks for the IsPassive value in the query parameters, if found
+ * parses the value which must be either "true" or "false".
+ *
+ * If not found returned flag defaults to FALSE.
+ */
+
+int am_get_is_passive(request_rec *r, int *is_passive)
+{
+    char *is_passive_str;
+    int ret = OK;
+
+    is_passive_str = am_extract_query_parameter(r->pool, r->args, "IsPassive");
+    if(is_passive_str != NULL) {
+        ret = am_urldecode((char*)is_passive_str);
+        if(ret != OK) {
+            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                          "Error urldecoding IsPassive parameter.");
+            return ret;
+        }
+        if(!strcmp(is_passive_str, "true")) {
+            *is_passive = TRUE;
+        } else if(!strcmp(is_passive_str, "false")) {
+            *is_passive = FALSE;
+        } else {
+            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                          "Invalid value for IsPassive parameter - must be \"true\" or \"false\".");
+            return HTTP_BAD_REQUEST;
+        }
+    } else {
+        *is_passive = FALSE;
+    }
+
+    return ret;
+}
+
+/*
+ * Get the URL of the AssertionConsumerServer having specific protocol
+ * binding.
+ *
+ * Parameters:
+ *  LassoProvider *provider The provider whose endpoints will be scanned.
+ *  const char *binding     The required binding short name.
+ *
+ * Returns:
+ *   The endpoint URL or NULL if not found. Must be freed with g_free().
+ *
+ * Lasso does not provide a public API to select a provider endpoint
+ * by binding. The best we can do is iterate over a list of endpoint
+ * descriptors and select a matching descriptor.
+ *
+ * Lasso does not document the format of these descriptor names but
+ * essentially a descriptor is a space separated concatenation of the
+ * endpoint properties. For SAML2 one can assume it is the endpoint
+ * type, optionally followed by the protocol binding name, optionally
+ * followd by the index (if the endpoint type is indexed). If the
+ * endpoint is a response location then "ResponseLocation" will be
+ * appended as the final token. For example here is a list of
+ * descriptors returned for a service provider (note they are
+ * unordered).
+ *
+ *    "AssertionConsumerService HTTP-POST 0"
+ *    "AuthnRequestsSigned"
+ *    "AssertionConsumerService PAOS 2"
+ *    "SingleLogoutService HTTP-Redirect"
+ *    "SingleLogoutService SOAP"
+ *    "AssertionConsumerService HTTP-Artifact 1"
+ *    "NameIDFormat"
+ *    "SingleLogoutService HTTP-POST ResponseLocation"
+ *
+ * The possible binding names are:
+ *
+ *    "SOAP"
+ *    "HTTP-Redirect"
+ *    "HTTP-POST"
+ *    "HTTP-Artifact"
+ *    "PAOS"
+ *    "URI"
+ *
+ * We know the AssertionConsumerService is indexed. If there is more
+ * than one endpoint with the required binding we select the one with
+ * the lowest index assuming it is preferred.
+ */
+
+char *am_get_assertion_consumer_service_by_binding(LassoProvider *provider, const char *binding)
+{
+    GList *descriptors;
+    char *url;
+    char *selected_descriptor;
+    char *descriptor;
+    char **tokens;
+    guint n_tokens;
+    GList *i;
+    char *endptr;
+    long descriptor_index, min_index;
+
+    url = NULL;
+    selected_descriptor = NULL;
+    min_index = LONG_MAX;
+
+    /* The descriptor list is unordered */
+    descriptors = lasso_provider_get_metadata_keys_for_role(provider,
+                                                            LASSO_PROVIDER_ROLE_SP);
+
+    for (i = g_list_first(descriptors), tokens=NULL;
+         i;
+         i = g_list_next(i), g_strfreev(tokens)) {
+
+        descriptor = i->data;
+        descriptor_index = LONG_MAX;
+
+        /*
+         * Split the descriptor into tokens, only consider descriptors
+         * which have at least 3 tokens and whose first token is
+         * AssertionConsumerService
+         */
+
+        tokens = g_strsplit(descriptor, " ", 0);
+        n_tokens = g_strv_length(tokens);
+
+        if (n_tokens < 3) continue;
+
+        if (!g_str_equal(tokens[0], "AssertionConsumerService")) continue;
+        if (!g_str_equal(tokens[1], binding)) continue;
+
+        descriptor_index = strtol(tokens[2], &endptr, 10);
+        if (tokens[2] == endptr) continue; /* could not parse int */
+
+        if (descriptor_index < min_index) {
+            selected_descriptor = descriptor;
+            min_index = descriptor_index;
+        }
+    }
+
+    if (selected_descriptor) {
+        url = lasso_provider_get_metadata_one(provider, selected_descriptor);
+    }
+
+    lasso_release_list_of_strings(descriptors);
+
+    return url;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,8 @@ AC_CHECK_LIB(lasso, lasso_server_load_metadata,
              LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_lasso_server_load_metadata")
 AC_CHECK_LIB(lasso, lasso_profile_set_signature_verify_hint,
              LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_lasso_profile_set_signature_verify_hint")
+AC_CHECK_LIB(lasso, lasso_ecp_request_new,
+             LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_ECP")
 LIBS=$saved_LIBS;
 AC_SUBST(LASSO_CFLAGS)
 AC_SUBST(LASSO_LIBS)
@@ -71,6 +73,17 @@ AC_SUBST(OPENSSL_LIBS)
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.12])
 AC_SUBST(GLIB_CFLAGS)
 AC_SUBST(GLIB_LIBS)
+
+# Test to see if we can include lasso/utils.h
+# AC_CHECK_HEADER won't work correctly unless we specifiy the include directories
+# found in the LASSO_CFLAGS. Save and restore CFLAGS and CPPFLAGS.
+saved_CFLAGS=$CFLAGS
+saved_CPPFLAGS=$CPPFLAGS
+CFLAGS="$CFLAGS $pkg_cv_LASSO_CFLAGS"
+CPPFLAGS="$CPPFLAGS $pkg_cv_LASSO_CFLAGS"
+AC_CHECK_HEADER([lasso/utils.h], LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_LASSO_UTILS_H")
+CFLAGS=$saved_CFLAGS
+CPPFLAGS=$saved_CPPFLAGS
 
 
 # Create Makefile from Makefile.in

--- a/lasso_compat.h
+++ b/lasso_compat.h
@@ -1,0 +1,50 @@
+#ifdef HAVE_LASSO_UTILS_H
+
+#include <lasso/utils.h>
+
+#else
+
+#define lasso_assign_string(dest,src)           \
+{                                               \
+    char *__tmp = g_strdup(src);                \
+    lasso_release_string(dest);                 \
+    dest = __tmp;                               \
+}
+
+#define lasso_release_string(dest)              \
+	lasso_release_full(dest, g_free)
+
+#define lasso_release_full(dest, free_function) \
+{                                               \
+    if (dest) {                                 \
+        free_function(dest); dest = NULL;       \
+    }                                           \
+}
+
+#define lasso_check_type_equality(a,b)
+
+#define lasso_release_full2(dest, free_function, type)  \
+{                                                       \
+    lasso_check_type_equality(dest, type);              \
+    if (dest) {                                         \
+        free_function(dest); dest = NULL;               \
+    }                                                   \
+}
+
+#define lasso_release_list(dest)                        \
+	lasso_release_full2(dest, g_list_free, GList*)
+
+#define lasso_release_list_of_full(dest, free_function)         \
+{                                                               \
+    GList **__tmp = &(dest);                                    \
+    if (*__tmp) {                                               \
+        g_list_foreach(*__tmp, (GFunc)free_function, NULL);     \
+        lasso_release_list(*__tmp);                             \
+    }                                                           \
+}
+
+#define lasso_release_list_of_strings(dest)     \
+	lasso_release_list_of_full(dest, g_free)
+
+
+#endif

--- a/mod_auth_mellon.c
+++ b/mod_auth_mellon.c
@@ -182,12 +182,30 @@ static void am_child_init(apr_pool_t *p, server_rec *s)
 }
 
 
+static int am_create_request(request_rec *r)
+{
+    am_req_cfg_rec *req_cfg;
+
+    req_cfg = apr_pcalloc(r->pool, sizeof(am_req_cfg_rec));
+
+    req_cfg->cookie_value = NULL;
+#ifdef HAVE_ECP
+    req_cfg->ecp_authn_req = false;
+#endif /* HAVE_ECP */
+
+    ap_set_module_config(r->request_config, &auth_mellon_module, req_cfg);
+
+    return OK;
+}
+
+
 static void register_hooks(apr_pool_t *p)
 {
     ap_hook_access_checker(am_auth_mellon_user, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_check_user_id(am_check_uid, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_post_config(am_global_init, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_child_init(am_child_init, NULL, NULL, APR_HOOK_MIDDLE);
+    ap_hook_create_request(am_create_request, NULL, NULL, APR_HOOK_MIDDLE);
 
     /* Add the hook to handle requests to the mod_auth_mellon endpoint.
      *


### PR DESCRIPTION
The modifications in this commit address the changes necessary to
support the SP component of SAML ECP. The Lasso library needs
additional modifications before SAML ECP will be fully functional,
those fixes have been submitted to upstream Lasso, mod_auth_mellon
will continue to operate correctly without the Lasso upgrade, it just
won't properly support ECP without the Lasso fixes.

Below are the major logical changes in the commit and the rationale
behind them.

* Allow compilation against older versions of Lasso by conditionally
  compiling.

  Add the following CPP symbols set by configure:

  * HAVE_ECP
  * HAVE_LASSO_UTILS_H

* Add lasso_compat.h

  If we can't include lasso utils.h than pull in our own
  local definitions so we can use some of the valuable
  utilities.

* Add ECP specific documentation file

  Documentation specific to ECP is now contained in ECP.rst
  (using reStructuredText formatting). Information on general ECP
  concepts, mod_auth_mellon user information, and internal
  mod_auth_mellon coding issues are covered.

* Add am_get_is_passive() utility

  Add utilty to get the IsPassive flag so it can be called
  from multiple places.

* Add am_validate_paos_header() utility

  This utility routine validates the PAOS HTTP header. It is used
  in conjunction with am_header_has_media_type() to determine if a
  client is ECP capable.

* Add utility function am_header_has_media_type() to check if an HTTP
  Accept header includes a specific media type. This is necessary
  because the SP detects an ECP client by the presence of a
  application/vnd.paos+xml media type in the Accept
  header. Unfortunately neither Apache nor mod_auth_mellon already had
  a function to check Accept media types so this was custom written
  and added to mod_auth_mellon.

* Add utility function am_get_assertion_consumer_service_by_binding()
  because Lasso does not expose that in it's public API. It's
  necessary to get the URL of the PAOS AssertionConsumerService.

* Add MellonECPSendIDPList config option

  This option controls whether to include a list of IDP's when
  sending an ECP PAOS <AuthnRequest> message to an ECP client.

* We need to do some bookkeeping during the processing of a
  request. Some Apache modules call this "adding a
  note". mod_auth_mellon was already doing this but because it only
  needed to track one value (the cookie value) took a shortcut and
  stuffed the cookie value into the per module request slot rather
  than defining a struct that could hold a variety of per-request
  values. To accommodate multiple per request bookkeeping values we
  define a new struct, am_req_cfg_rec, that holds the previously used
  cookie value and adds a new ECP specific value. This struct is now
  the bookkeeping data item attached to each request. To support the
  new am_req_cfg_rec struct the am_get_req_cfg macro was added (mirrors
  the existing am_get_srv_cfg, am_get_mod_cfg and am_get_dir_cfg
  macros). The am_create_request() Apache hook was added to
  initialize the am_req_cfg_rec at the beginning of the request
  pipeline.

* A new endpoint was added to handle PAOS responses from the ECP
  client. The endpoint is called "paosResponse" and lives along side
  of the existing endpoints (e.g. postResponse, artifactResponse,
  metadata, auth, logout, etc.). The new endpoint is handled by
  am_handle_paos_reply(). The metadata generation implemented in
  am_generate_metadata() was augmented to add the paosResponse
  endpoint and bind it to the SAML2 PAOS binding.

* am_handle_reply_common() was being called by am_handle_post_reply()
  and am_handle_artifact_reply() because replies share a fair amount
  of common logic. The new am_handle_paos_reply() also needs to
  utilize the same common logic in am_handle_reply_common() but ECP
  has slightly different behavior that has to be accounted for. With
  ECP there is no SP generated cookie because the SP did not initiate
  the process and has no state to track. Also the RelayState is
  optional with ECP and is carried in the PAOS header as opposed to an
  HTTP query/post parameter. The boolean flag is_paos was added as a
  parameter to am_handle_reply_common() so as to be able to
  distinguish between the PAOS and non-PAOS logic.

* Add PAOS AssertionConsumerService to automatically generated metadata.
  Note, am_get_assertion_consumer_service_by_binding() should be able
  to locate this endpoint.

* Refactor code to send <AuthnRequest>, now also supports PAOS

  The creation and initialization of a LassoLogin object is different
  for the ECP case. We want to share as much common code as possible,
  the following refactoring was done to achieve that goal.

  The function am_send_authn_request() was removed and it's logic
  moved to am_init_authn_request_common(),
  am_send_login_authn_request() and
  am_set_authn_request_content(). This allows the logic used to create
  and initialize a LassoLogin object to be shared between the PAOS and
  non-PAOS cases. am_send_paos_authn_request() also calls
  am_init_authn_request_common() and
  am_set_authn_request_content(). The function
  am_set_authn_request_content() replaces the logic at the end of
  am_send_authn_request(), it is responsible for setting the HTTP
  headers and body content based on the LassoLogin.

Signed-off-by: John Dennis <jdennis@redhat.com>