### PR TITLE
Add max-age=0 to the Cache-Control header to prevent stale content read from logged out users

### DIFF
--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -410,6 +410,10 @@ void am_set_cache_control_headers(request_rec *r)
     /* Send Cache-Control header to ensure that:
      * - no proxy in the path caches content inside this location (private),
      * - user agent have to revalidate content on server (must-revalidate).
+     * - content is always stale as the session login status can change at any
+     *   time synchronously (Redirect logout, session cookie is removed) or
+     *   asynchronously (SOAP logout, session cookie still exists but is
+     *   invalid),
      *
      * But never prohibit specifically any user agent to cache or store content
      *
@@ -417,7 +421,7 @@ void am_set_cache_control_headers(request_rec *r)
      * sent for all responses.
      */
     apr_table_setn(r->err_headers_out,
-                   "Cache-Control", "private, must-revalidate");
+                   "Cache-Control", "private, max-age=0, must-revalidate");
 }
 
 /* This function reads the post data for a request.


### PR DESCRIPTION
As for cache-control we know that page protected by mod_mellon are
private and can vary depending on the current session. To prevent
navigator to show stale page after a logout we must set that the cached
page depends upon the value of the cookie header by setting the Vary
header. Without it navigators would be free to show page cached under a
connected session to anonymous users.