### PR TITLE
Add support for SAML ECP.

### DIFF
--- a/ECP.rst
+++ b/ECP.rst
@@ -1,0 +1,286 @@
+Guide to using ECP
+==================
+
+Introduction
+------------
+
+The **Enhanced Client or Proxy** (ECP) profile of SAML2
+
+The Enhanced Client or Proxy (ECP) Profile supports several SSO use
+cases, in particular:
+
+  * Clients with capabilities beyond those of a browser, allowing them
+    to more actively participate in IdP discovery and message flow.
+
+  * Using a proxy server, for example a WAP gateway in front of a mobile
+    device which has limited functionality.
+
+  * When other bindings are precluded (e.g. where the client does not
+    support redirects, or when auto form post is not possible without
+    Javascript, or when the artifact binding is ruled out because the
+    identity provider and service provider cannot directly communicate.
+
+An enhanced client or proxy (ECP) is a system entity that knows how to
+contact an appropriate identity provider, possibly in a
+context-dependent fashion, and also supports the Reverse SOAP (PAOS)
+binding.
+
+An example scenario enabled by ECP profile is as follows: A principal,
+wielding an ECP, uses it to either access a resource at a service
+provider, or access an identity provider such that the service
+provider and desired resource are understood or implicit. The
+principal authenticates (or has already authenticated) with the
+identity provider [1]_, which then produces an authentication assertion
+(possibly with input from the service provider). The service provider
+then consumes the assertion and subsequently establishes a security
+context for the principal. During this process, a name identifier
+might also be established between the providers for the principal,
+subject to the parameters of the interaction and the consent of the
+principal.
+
+SAML2 Profile for ECP (Section 4.2) defines these steps for an ECP
+transaction:
+
+  1. ECP issues HTTP Request to SP
+  2. SP issues <AuthnRequest> to ECP using PAOS
+  3. ECP determines IdP
+  4. ECP conveys <AuthnRequest> to IdP using SOAP
+  5. IdP identifies principal
+  6. IdP issues <Response> to ECP, targeted at SP using SOAP
+  7. ECP conveys <Response> to SP using PAOS
+  8. SP grants or denies access to principal
+
+mod_auth_mellon and ECP
+-----------------------
+
+mod_auth_mellon plays the role of the SP in an ECP transaction.
+
+mod_auth_mellon utilizes the Lasso library to provide it's SAML2
+functionality. Fully functioning SAML2 ECP support in Lasso is
+relatively new. When mod_auth_mellon is built it detects the presence
+of SAML2 ECP in Lasso and only compiles in the ECP code in
+mod_auth_mellon if it's present in Lasso.
+
+How does mod_auth_mellon recognize a request is from an ECP client?
+```````````````````````````````````````````````````````````````````
+
+In Step 1. when the ECP client issues the HTTP Request to the SP it
+**MUST** include `application/vnd.paos+xml` as a mime type in the HTTP
+`Accept` header field and include an HTTP `PAOS` header specifying a
+PAOS version of `urn:liberty:paos:2003-08` and an ECP service
+declaration of `urn:oasis:names:tc:SAML:2.0:profiles:SSO:ecp` [2]_,
+for example::
+
+  Accept: text/html, application/vnd.paos+xml
+  PAOS: ver="urn:liberty:paos:2003-08";"urn:oasis:names:tc:SAML:2.0:profiles:SSO:ecp"
+
+If mod_auth_mellon sees this in the incoming request it knows the
+client is ECP aware and capable. If authentication is required
+mod_auth_mellon will initiate an ECP flow.
+
+The role of IdP's in ECP
+````````````````````````
+
+The SAML2 ECP profile states it is the ECP client which determines the
+IdP that will be used for authentication. This is in contrast to the
+Web SSO flow where the SP determines the IdP. However, the ECP
+protocol permits an SP to send the ECP client a list of IdP's it
+trusts. It is optional if the SP sends an IDPList, if it does the ECP
+client should select the IdP from the SP provided IDPList otherwise
+the ECP client is free to select any IdP it wishes.
+
+If the mellon configuration option `MellonECPSendIDPList` is true then
+mod_auth_mellon will include an IDPList when it returns a PAOS
+<AuthnRequest> to the ECP client.
+
+To build the IDPList mod_auth_mellon scans it's list of loaded IdP's
+selecting those which are ECP capable. To support ECP an IdP must
+advertise the SingleSignOn service utilizing the SOAP binding.
+
+ECP specific mod_auth_mellon configuration directives
+`````````````````````````````````````````````````````
+
+These configuration directives are specific to ECP:
+
+MellonECPSendIDPList
+  If `On` mod_auth_mellon will send an IdP list to the ECP client
+  containing only those IdP's capable of ECP flow. The ECP client
+  should select an IdP only from this list. If this option is `Off`
+  no IdP list will be sent and the ECP client is free to select any
+  IdP.
+
+Example ECP client
+``````````````````
+
+To illustrate a simple ECP client based on Lasso we'll use the Lasso
+Python binding (as opposed to pseudo code, Python is quite
+readable). All error checking and another necessary ancillary code has
+been eliminated in order to clearly illustrate only the ECP
+operations.
+
+.. code-block:: python
+
+  import lasso
+  import requests
+
+  ecp = lasso.Ecp(server)
+  session = requests.Session()
+
+  MEDIA_TYPE_PAOS = 'application/vnd.paos+xml'
+  PAOS_HEADER = 'ver="%s";"%s"' % (lasso.PAOS_HREF,lasso.ECP_HREF)
+
+  # Step 1: Request protected resource, indicate ECP capable
+  response = session.get(protected, headers={'Accept': MEDIA_TYPE_PAOS,
+                                             'PAOS': PAOS_HEADER})
+
+  # Process returned PAOS wrapped <AuthnRequest>
+  ecp.processAuthnRequestMsg(response.text)
+
+  # Post SOAP wrapped <AuthnRequest> to IdP, use Digest Auth to authenticate
+  response = session.post(ecp.msgUrl,
+                          data=ecp.msgBody,
+                          auth=requests.auth.HTTPDigestAuth(user, password)
+                          headers={'Content-Type': 'application/soap+xml'})
+
+  # Process returned SOAP wrapped <Assertion> from IdP
+  ecp.processResponseMsg(response.text)
+
+  # Post PASO wrapped <Assertion> to SP, response is protected resource
+  response = session.post(ecp.msgUrl,
+                          data=ecp.msgBody,
+                          headers={'Content-Type': 'application/vnd.paos+xml'})
+
+
+mod_auth_mellon internal ECP implementation notes
+-------------------------------------------------
+
+
+Notes on ECP vs. Web SSO flow
+`````````````````````````````
+
+Web SSO (Single Sign-On) flow is by far the most common and what
+most people are familiar with when they think of SAML. The Web SSO
+profile is designed so that browsers ignorant of SAML can perform
+SAML authentication without modification. This is accomplished with
+existing HTTP paradigms such as redirects, form posts, etc. which a
+browser will process normally yielding the desired result.
+
+ECP (Enhanced Client or Proxy) is a different SAML profile that
+also accomplishes SSO (Single Sign-On). The distinction is an ECP
+client is fully SAML aware and actively participates in the SAML
+conversation.
+
+Web SSO and ECP have very different flows, mod_auth_mellon must
+support both flows. mod_auth_mellon is a SP (Service Provider).
+
+IdP Selection Differences
+`````````````````````````
+
+With Web SSO the SP determines the IdP and redirects there.
+
+With ECP the ECP client determines the IdP, the SP has no a prori
+knowledge of the target IdP, although the SP may provide a
+suggested list of IdP's when responding to the ECP client.
+
+Since with ECP it is the ECP client which selects the IdP the set of
+IdP's loaded into mod_auth_mellon are not relevant **except** if
+`MellonECPSendIDPList` is enabled. In this case mod_auth_mellon will
+filter the set of loaded IdP's and forward those IdP's supporting
+SingleSignOn with the SOAP binding.
+
+Apache request processing pipeline
+``````````````````````````````````
+
+Apache implements a request processing pipeline composed of
+stages. An Apache extension module can participate in the pipeline
+by asking to be called at specific stages (steps) by registering a
+hook function for that stage. Final content returned to the HTTP
+client in the HTTP response is generated in the "handler", one of
+the final stages in the request processing pipeline.
+
+One of the stages in the request pipeline is determining
+authentication and authorization for protected resources. If a
+resource is protected and the authentication and authorization
+pipeline stages deny access or fail the request processing pipeline
+is aborted early, a non-success HTTP response is returned, the
+content handler is never reached.
+
+With Web SSO if authentication needs to be performed a redirect will
+be returned that redirects to a SAML endpoint (login) on our SP. This
+in turn generates the SAML <AuthnRequest> with a redirect to the
+IdP. All of this is very vanilla standard HTTP easily accommodated by
+Apache's request processing pipeline which is designed to handle these
+types of flows.
+
+ECP requires special handling
+`````````````````````````````
+
+However ECP has a very different flow. When an ECP client sends a
+request to the SP it includes a special HTTP headers indicating it is
+ECP capable. If the SP determines the resource is protected and
+authentication is needed and the client has signaled it is ECP capable
+then the SP responds successfully (200) with a SAML <AuthnRequest>
+wrapped in PAOS. *This is very different than conventional HTTP
+request processing.* Here we have a case where there is a protected
+resource that has **not** been authenticated yet the web server will
+responds with an HTTP 200 success and content! One might normally
+expect a HTTP 401 or redirect response for a protected resource when
+there is no authenticated user. *This is clearly contrary to the
+expectations of Apache's request processing pipeline.*
+
+Reaching the Apache content handler
+```````````````````````````````````
+
+In order to be able to return a successful (HTTP 200) PAOS response
+when doing the ECP we have to reach the part of Apache's request
+processing pipeline that generates the response. In Apache terminology
+this is called a (content) handler.
+
+At an early stage we detect if authentication is required. For the
+normal Web SSO profile we would redirect the client back to our login
+endpoint which will be handled by our handler in a different
+request. But for ECP the current request must proceed. We set a flag
+on the request indicating ECP authentication is required. The pipeline
+continues. When the pipeline reaches the authentication and
+authorization stages we check the ECP flag on the request, if ECP
+authentication is indicated we lie and tell the pipeline the user is
+authenticated and authorized. We do this only so we can reach the
+handler stage (otherwise because the request is for a protected
+resource the pipeline would terminate with an error). Despite our
+having forced authentication and authorization to be valid for the
+protected resource the request processing pipeline *will not return the
+protected resource* because we will subsequently intercept the request
+in our handler before the pipeline reaches the point of returning the
+protected resource.
+
+At the handler stage
+````````````````````
+
+Once our handler is invoked it has 3 possible actions to perform:
+
+  1. The request is for one of our SAML endpoints (e.g. login,
+  logout, metadata, etc.) We dispatch to the handler for the specific
+  action. We detect this case by matching the request URI to our SAML
+  endpoints. We signal to the pipeline that our hook handled the request.
+
+  2. The request is for a protected resource and needs ECP
+  authentication performed. We detect this case by examining the ECP flag
+  set on the request by an earlier hook function. The request URI is
+  for the protected resource and has nothing to do with our SAML
+  endpoints. We generate the PAOS <AuthnRequest> and respond with
+  success (200) and signal to the pipeline that our hook handled the
+  request. Note, we have not returned the protected resource, instead
+  we've returned the PAOS request.
+
+  3. The request has nothing to do with us, we decline to handle
+  it. The pipeline proceeds to the next handler.
+
+
+.. [1] The means by which a principal authenticates with an identity
+       provider is outside of the scope of SAML. Typically an ECP
+       client will utilize an HTTP authentication method when posting
+       the <AuthnRequest> SOAP message to the IdP.
+
+.. [2] Contrary to most HTTP headers the values in the PAOS header must
+       be enclosed in double quotes. A semicolon is used to separate
+       the values.

--- a/Makefile.in
+++ b/Makefile.in
@@ -11,11 +11,13 @@ SRC=mod_auth_mellon.c \
 DISTFILES=$(SRC) \
 	auth_mellon.h \
 	auth_mellon_compat.h \
+	lasso_compat.h \
 	configure \
 	configure.ac \
 	Makefile.in \
 	autogen.sh \
 	README \
+	ECP.rst \
 	COPYING \
 	NEWS
 

--- a/README
+++ b/README
@@ -527,6 +527,10 @@ MellonPostCount 100
         # The default is to not redirect, but rather send a
         # 401 Unautorized error.
 
+        # This option controls whether to include a list of IDP's when
+        # sending an ECP PAOS <AuthnRequest> message to an ECP client.
+        MellonECPSendIDPList Off
+
 </Location>
 
 

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -85,7 +85,6 @@ static const int default_env_vars_index_start = -1;
  */
 static const int default_env_vars_count_in_n = -1;
 
-
 /* This function handles configuration directives which set a 
  * multivalued string slot in the module configuration (the destination
  * strucure is a hash).
@@ -1289,6 +1288,13 @@ const command_rec auth_mellon_commands[] = {
         OR_AUTHCFG,
         "Whether to also populate environment variable suffixed _N with number of values. Default is off."
         ),
+    AP_INIT_FLAG(
+        "MellonECPSendIDPList",
+        ap_set_flag_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, ecp_send_idplist),
+        OR_AUTHCFG,
+        "Whether to send an ECP client a list of IdP's. Default is off."
+        ),
     {NULL}
 };
 
@@ -1385,6 +1391,8 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->subject_confirmation_data_address_check = inherit_subject_confirmation_data_address_check;
     dir->do_not_verify_logout_signature = apr_hash_make(p);
     dir->post_replay = inherit_post_replay;
+
+    dir->ecp_send_idplist = inherit_ecp_send_idplist;
 
     return dir;
 }
@@ -1614,6 +1622,8 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
     new_cfg->subject_confirmation_data_address_check =
         CFG_MERGE(add_cfg, base_cfg, subject_confirmation_data_address_check);
     new_cfg->post_replay = CFG_MERGE(add_cfg, base_cfg, post_replay);
+
+    new_cfg->ecp_send_idplist = CFG_MERGE(add_cfg, base_cfg, ecp_send_idplist);
 
     return new_cfg;
 }

--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -83,6 +83,7 @@ static const char *am_cookie_params(request_rec *r)
  */
 const char *am_cookie_get(request_rec *r)
 {
+    am_req_cfg_rec *req_cfg;
     const char *name;
     const char *value;
     const char *cookie;
@@ -96,8 +97,8 @@ const char *am_cookie_get(request_rec *r)
     }
 
     /* Check if we have added a note on the current request. */
-    value = (const char *)ap_get_module_config(r->request_config,
-                                               &auth_mellon_module);
+    req_cfg = am_get_req_cfg(r);
+    value = req_cfg->cookie_value;
     if(value != NULL) {
         return value;
     }
@@ -180,6 +181,7 @@ const char *am_cookie_get(request_rec *r)
  */
 void am_cookie_set(request_rec *r, const char *id)
 {
+    am_req_cfg_rec *req_cfg;
     const char *name;
     const char *cookie_params;
     char *cookie;
@@ -202,8 +204,8 @@ void am_cookie_set(request_rec *r, const char *id)
     /* Add a note on the current request, to allow us to retrieve this
      * cookie in the current request.
      */
-    ap_set_module_config(r->request_config, &auth_mellon_module,
-                         apr_pstrdup(r->pool, id));
+    req_cfg = am_get_req_cfg(r);
+    req_cfg->cookie_value = apr_pstrdup(r->pool, id);
 }
 
 

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -23,6 +23,13 @@
 #include "auth_mellon.h"
 
 
+/*
+ * Note:
+ *
+ * Information on PAOS ECP vs. Web SSO flow processing can be found in
+ * the ECP.rst file.
+ */
+
 #ifdef HAVE_lasso_server_new_from_buffers
 #  define SERVER_NEW lasso_server_new_from_buffers
 #else /* HAVE_lasso_server_new_from_buffers */
@@ -197,11 +204,15 @@ static char *am_generate_metadata(apr_pool_t *p, request_rec *r)
      index=\"1\"\n\
      Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact\"\n\
      Location=\"%sartifactResponse\" />\n\
+   <AssertionConsumerService\n\
+     index=\"2\"\n\
+     Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:PAOS\"\n\
+     Location=\"%spaosResponse\" />\n\
  </SPSSODescriptor>\n\
  %s\n\
 </EntityDescriptor>",
       sp_entity_id, cfg->sp_entity_id ? "" : "metadata", 
-      cert, url, url, url, url, am_optional_metadata(p, r));
+      cert, url, url, url, url, url, am_optional_metadata(p, r));
 }
 #endif /* HAVE_lasso_server_new_from_buffers */
 
@@ -1649,12 +1660,14 @@ static int am_validate_authn_context_class_ref(request_rec *r,
  *                       the request url. This parameter is urlencoded, and
  *                       this function will urldecode it in-place. Therefore it
  *                       must be possible to overwrite the data.
+ *  is_paos              If true then flow is PAOS ECP.
  *
  * Returns:
  *  A HTTP status code which should be returned to the client.
  */
 static int am_handle_reply_common(request_rec *r, LassoLogin *login,
-                                  char *relay_state, char *saml_response)
+                                  char *relay_state, char *saml_response,
+                                  bool is_paos)
 {
     char *url;
     char *chr;
@@ -1739,25 +1752,27 @@ static int am_handle_reply_common(request_rec *r, LassoLogin *login,
     in_response_to = response->parent.InResponseTo;
 
 
-    if(in_response_to != NULL) {
-        /* This is SP-initiated login. Check that we have a cookie. */
-        if(am_cookie_get(r) == NULL) {
-            /* Missing cookie. */
-            ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r,
-                          "User has disabled cookies, or has lost"
-                          " the cookie before returning from the SAML2"
-                          " login server.");
-            if(dir_cfg->no_cookie_error_page != NULL) {
-                apr_table_setn(r->headers_out, "Location",
-                               dir_cfg->no_cookie_error_page);
-                lasso_login_destroy(login);
-                return HTTP_SEE_OTHER;
-            } else {
-                /* Return 400 Bad Request when the user hasn't set a
-                 * no-cookie error page.
-                 */
-                lasso_login_destroy(login);
-                return HTTP_BAD_REQUEST;
+    if (!is_paos) {
+        if(in_response_to != NULL) {
+            /* This is SP-initiated login. Check that we have a cookie. */
+            if(am_cookie_get(r) == NULL) {
+                /* Missing cookie. */
+                ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r,
+                              "User has disabled cookies, or has lost"
+                              " the cookie before returning from the SAML2"
+                              " login server.");
+                if(dir_cfg->no_cookie_error_page != NULL) {
+                    apr_table_setn(r->headers_out, "Location",
+                                   dir_cfg->no_cookie_error_page);
+                    lasso_login_destroy(login);
+                    return HTTP_SEE_OTHER;
+                } else {
+                    /* Return 400 Bad Request when the user hasn't set a
+                     * no-cookie error page.
+                     */
+                    lasso_login_destroy(login);
+                    return HTTP_BAD_REQUEST;
+                }
             }
         }
     }
@@ -1961,9 +1976,95 @@ static int am_handle_post_reply(request_rec *r)
                                                "RelayState");
 
     /* Finish handling the reply with the common handler. */
-    return am_handle_reply_common(r, login, relay_state, saml_response);
+    return am_handle_reply_common(r, login, relay_state, saml_response, false);
 }
 
+
+/* This function handles responses to login requests received with the
+ * PAOS binding.
+ *
+ * Parameters:
+ *  request_rec *r       The request we received.
+ *
+ * Returns:
+ *  HTTP_SEE_OTHER on success, or an error on failure.
+ */
+static int am_handle_paos_reply(request_rec *r)
+{
+    int rc;
+    char *post_data;
+    LassoServer *server;
+    LassoLogin *login;
+    char *relay_state = NULL;
+    int i, err;
+
+    /* Make sure that this is a POST request. */
+    if(r->method_number != M_POST) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                      "Expected POST request for paosResponse endpoint."
+                      " Got a %s request instead.", r->method);
+
+        /* According to the documentation for request_rec, a handler which
+         * doesn't handle a request method, should set r->allowed to the
+         * methods it handles, and return DECLINED.
+         * However, the default handler handles GET-requests, so for GET
+         * requests the handler should return HTTP_METHOD_NOT_ALLOWED.
+         */
+        r->allowed = M_POST;
+
+        if(r->method_number == M_GET) {
+            return HTTP_METHOD_NOT_ALLOWED;
+        } else {
+            return DECLINED;
+        }
+    }
+
+    /* Read POST-data. */
+    rc = am_read_post_data(r, &post_data, NULL);
+    if (rc != OK) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, rc, r,
+                      "Error reading POST data.");
+        return rc;
+    }
+
+    server = am_get_lasso_server(r);
+    if(server == NULL) {
+        return HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    login = lasso_login_new(server);
+    if (login == NULL) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                      "Failed to initialize LassoLogin object.");
+        return HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    /* Process login response. */
+    rc = lasso_login_process_paos_response_msg(login, post_data);
+    if (rc != 0) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                      "Error processing ECP authn response."
+                      " Lasso error: [%i] %s", rc, lasso_strerror(rc));
+
+        lasso_login_destroy(login);
+        err = HTTP_BAD_REQUEST;
+        for (i = 0; auth_mellon_errormap[i].lasso_error != 0; i++) {
+            if (auth_mellon_errormap[i].lasso_error == rc) {
+                err = auth_mellon_errormap[i].http_error;
+                break;
+            }
+        }
+        return err;
+    }
+
+    /* Extract RelayState parameter. */
+    if (LASSO_PROFILE(login)->msg_relayState) {
+        relay_state = apr_pstrdup(r->pool, LASSO_PROFILE(login)->msg_relayState);
+    }
+
+    /* Finish handling the reply with the common handler. */
+    return am_handle_reply_common(r, login, relay_state, post_data, true);
+}
 
 /* This function handles responses to login requests which use the
  * HTTP-Artifact binding.
@@ -2097,7 +2198,7 @@ static int am_handle_artifact_reply(request_rec *r)
     }
 
     /* Finish handling the reply with the common handler. */
-    return am_handle_reply_common(r, login, relay_state, "");
+    return am_handle_reply_common(r, login, relay_state, "", false);
 }
 
 
@@ -2422,9 +2523,7 @@ static int am_handle_metadata(request_rec *r)
 }
 
 
-/* Send AuthnRequest using HTTP-Redirect binding.
- *
- * Note that this method frees the LassoLogin object.
+/* Use Lasso Login to set the HTTP content & headers for HTTP-Redirect binding.
  *
  * Parameters:
  *  request_rec *r
@@ -2433,7 +2532,7 @@ static int am_handle_metadata(request_rec *r)
  * Returns:
  *  HTTP_SEE_OTHER on success, or an error on failure.
  */
-static int am_send_authn_request_redirect(request_rec *r, LassoLogin *login)
+static int am_set_authn_request_redirect_content(request_rec *r, LassoLogin *login)
 {
     char *redirect_to;
 
@@ -2455,15 +2554,11 @@ static int am_send_authn_request_redirect(request_rec *r, LassoLogin *login)
     }
     apr_table_setn(r->headers_out, "Location", redirect_to);
 
-    lasso_login_destroy(login);
-
     /* We don't want to include POST data (in case this was a POST request). */
     return HTTP_SEE_OTHER;
 }
 
-/* Send AuthnRequest using HTTP-POST binding.
- *
- * Note that this method frees the LassoLogin object.
+/* Use Lasso Login to set the HTTP content & headers for HTTP-POST binding.
  *
  * Parameters:
  *  request_rec *r         The request we are processing.
@@ -2472,7 +2567,7 @@ static int am_send_authn_request_redirect(request_rec *r, LassoLogin *login)
  * Returns:
  *  OK on success, or an error on failure.
  */
-static int am_send_authn_request_post(request_rec *r, LassoLogin *login)
+static int am_set_authn_request_post_content(request_rec *r, LassoLogin *login)
 {
     char *url;
     char *message;
@@ -2482,8 +2577,6 @@ static int am_send_authn_request_post(request_rec *r, LassoLogin *login)
     url = am_htmlencode(r, LASSO_PROFILE(login)->msg_url);
     message = am_htmlencode(r, LASSO_PROFILE(login)->msg_body);
     relay_state = am_htmlencode(r, LASSO_PROFILE(login)->msg_relayState);
-
-    lasso_login_destroy(login);
 
     output = apr_psprintf(r->pool,
       "<!DOCTYPE html>\n"
@@ -2513,70 +2606,76 @@ static int am_send_authn_request_post(request_rec *r, LassoLogin *login)
     return OK;
 }
 
-/* Create and send an authentication request.
+/* Use Lasso Login to set the HTTP content & headers for PAOS binding.
  *
  * Parameters:
  *  request_rec *r         The request we are processing.
- *  const char *idp        The entityID of the IdP.
- *  const char *return_to  The URL we should redirect to when receiving the request.
- *  int is_passive         Whether to send a passive request.
+ *  LassoLogin *login      The login message.
  *
  * Returns:
- *  HTTP response code indicating success or failure.
+ *  OK on success, or an error on failure.
  */
-static int am_send_authn_request(request_rec *r, const char *idp,
-                           const char *return_to, int is_passive)
+static int am_set_authn_request_paos_content(request_rec *r, LassoLogin *login)
 {
-    LassoServer *server;
-    LassoProvider *provider;
-    LassoLogin *login;
-    LassoSamlp2AuthnRequest *request;
-    LassoHttpMethod http_method;
-    char *sso_url;
+    apr_table_setn(r->headers_out, "Content-Type", MEDIA_TYPE_PAOS);
+    ap_rputs(LASSO_PROFILE(login)->msg_body, r);
+
+    return OK;
+}
+
+/*
+ * Create and initialize LassoLogin object
+ *
+ * This function creates a LassoLogin object and initializes it to the
+ * greatest extent possible to allow it to be shared by multiple
+ * callers. There are two return values. The function return is an
+ * error code, the login_return parameter is a pointer in which to
+ * receive the LassoLogin object. The caller MUST free the returned
+ * login object using lasso_login_destroy() in all cases (even when
+ * this function returns an error), the only execption is if the
+ * returned LassoLogin is NULL.
+ *
+ * Parameters:
+ *  r                The request we are processing.
+ *  login_return     The returned LassoLogin object (caller must free)
+ *  idp              The provider id of remote Idp
+ *                   [optional, may be NULL]
+ *  http_method      Specifies the SAML profile to use
+ *  destination_url  If the idp parameter is non-NULL this should be
+ *                   the URL of the IdP endpoint the message is being sent to
+ *                   [optional, may be NULL]
+ *  assertion_consumer_service_url
+ *                   The URL of this SP's endpoint which will receive the
+ *                   SAML assertion
+ *  return_to_url    Used to initialize the RelayState value
+ *  is_passive       The SAML IsPassive flag
+ *
+ * Returns:
+ *  OK on success, HTTP error code otherwise
+ *
+ */
+static int am_init_authn_request_common(request_rec *r,
+                                        LassoLogin **login_return,
+                                        const char *idp,
+                                        LassoHttpMethod http_method,
+                                        const char *destination_url,
+                                        const char *assertion_consumer_service_url,
+                                        const char *return_to_url,
+                                        int is_passive)
+{
     gint ret;
     am_dir_cfg_rec *dir_cfg;
-    char *acs_url;
+    LassoServer *server;
+    LassoLogin *login;
+    LassoSamlp2AuthnRequest *request;
+    const char *sp_name;
+
+    *login_return = NULL;
 
     dir_cfg = am_get_dir_cfg(r);
 
-    /* Add cookie for cookie test. We know that we should have
-     * a valid cookie when we return from the IdP after SP-initiated
-     * login.
-     */
-    am_cookie_set(r, "cookietest");
-
-
     server = am_get_lasso_server(r);
-    if(server == NULL) {
-        return HTTP_INTERNAL_SERVER_ERROR;
-    }
-
-    /* Find our IdP. */
-    provider = lasso_server_get_provider(server, idp);
-    if (provider == NULL) {
-        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
-                      "Could not find metadata for the IdP \"%s\".",
-                      idp);
-        return HTTP_INTERNAL_SERVER_ERROR;
-    }
-
-    /* Determine what binding and endpoint we should use when
-     * sending the request.
-     */
-    http_method = LASSO_HTTP_METHOD_REDIRECT;
-    sso_url = lasso_provider_get_metadata_one(
-        provider, "SingleSignOnService HTTP-Redirect");
-    if (sso_url == NULL) {
-        /* HTTP-Redirect unsupported - try HTTP-POST. */
-        http_method = LASSO_HTTP_METHOD_POST;
-        sso_url = lasso_provider_get_metadata_one(
-            provider, "SingleSignOnService HTTP-POST");
-    }
-    if (sso_url == NULL) {
-        /* Both HTTP-Redirect and HTTP-POST unsupported - give up. */
-        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
-                      "Could not find a supported SingleSignOnService endpoint"
-                      " for the IdP \"%s\".", idp);
+    if (server == NULL) {
         return HTTP_INTERNAL_SERVER_ERROR;
     }
 
@@ -2584,34 +2683,56 @@ static int am_send_authn_request(request_rec *r, const char *idp,
     if(login == NULL) {
         ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
 		      "Error creating LassoLogin object from LassoServer.");
-        g_free(sso_url);
 	return HTTP_INTERNAL_SERVER_ERROR;
     }
+    *login_return = login;
 
     ret = lasso_login_init_authn_request(login, idp, http_method);
     if(ret != 0) {
         ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
                       "Error creating login request."
                       " Lasso error: [%i] %s", ret, lasso_strerror(ret));
-        g_free(sso_url);
-	lasso_login_destroy(login);
 	return HTTP_INTERNAL_SERVER_ERROR;
     }
 
     request = LASSO_SAMLP2_AUTHN_REQUEST(LASSO_PROFILE(login)->request);
-    if(request->NameIDPolicy == NULL) {
+    if (request->NameIDPolicy == NULL) {
         ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
                       "Error creating login request. Please verify the "
                       "MellonSPMetadataFile directive.");
-        g_free(sso_url);
-        lasso_login_destroy(login);
         return HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    /*
+     * Make sure the Destination attribute is set to the IdP
+     * SingleSignOnService endpoint. This is required for
+     * Shibboleth 2 interoperability, and older versions of
+     * lasso (at least up to 2.2.91) did not do it.
+     */
+    if (destination_url &&
+        LASSO_SAMLP2_REQUEST_ABSTRACT(request)->Destination == NULL) {
+        lasso_assign_string(LASSO_SAMLP2_REQUEST_ABSTRACT(request)->Destination,
+                            destination_url);
+    }
+
+    if (assertion_consumer_service_url) {
+        lasso_assign_string(request->AssertionConsumerServiceURL,
+                            assertion_consumer_service_url);
+        /* Can't set request->ProtocolBinding (which is usually set along side
+         * AssertionConsumerServiceURL) as there is no immediate function
+         * like lasso_provider_get_assertion_consumer_service_url to get them.
+         * So leave that empty for now, it is not strictly required */
     }
 
     request->ForceAuthn = FALSE;
     request->IsPassive = is_passive;
-
     request->NameIDPolicy->AllowCreate = TRUE;
+
+    sp_name = am_get_config_langstring(dir_cfg->sp_org_display_name, NULL);
+    if (sp_name) {
+        lasso_assign_string(request->ProviderName, sp_name);
+    }
+
 
     LASSO_SAMLP2_REQUEST_ABSTRACT(request)->Consent
       = g_strdup(LASSO_SAML2_CONSENT_IMPLICIT);
@@ -2638,56 +2759,227 @@ static int am_send_authn_request(request_rec *r, const char *idp,
         }
     }
 
-    /*
-     * Make sure the Destination attribute is set to the IdP
-     * SingleSignOnService endpoint. This is required for
-     * Shibboleth 2 interoperability, and older versions of
-     * lasso (at least up to 2.2.91) did not do it.
-     */
-    if (LASSO_SAMLP2_REQUEST_ABSTRACT(request)->Destination == NULL) {
-        LASSO_SAMLP2_REQUEST_ABSTRACT(request)->Destination = g_strdup(sso_url);
-    }
-
-    /* sso_url no longer needed. */
-    g_free(sso_url);
-
-    /* Some IdPs insist they want to see an AttributeConsumerServiceURL
-     * attribute in the authentication request, so try to add one if the
-     * metadata contains one */
-    acs_url = lasso_provider_get_assertion_consumer_service_url(
-        LASSO_PROVIDER(server), NULL);
-    if (acs_url) {
-        request->AssertionConsumerServiceURL = g_strdup(acs_url);
-        /* Can't set request->ProtocolBinding (which is usually set along side
-         * AssertionConsumerServiceURL) as there is no immediate function
-         * like lasso_provider_get_assertion_consumer_service_url to get them.
-         * So leave that empty for now, it is not strictly required */
-    }
-
-    LASSO_PROFILE(login)->msg_relayState = g_strdup(return_to);
+    LASSO_PROFILE(login)->msg_relayState = g_strdup(return_to_url);
 
     ret = lasso_login_build_authn_request_msg(login);
     if(ret != 0) {
         ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
                       "Error building login request."
                       " Lasso error: [%i] %s", ret, lasso_strerror(ret));
-	lasso_login_destroy(login);
 	return HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    /* Time to actually send the authentication request. */
-    switch (http_method) {
+    return OK;
+}
+
+/* Use Lasso Login to set the HTTP content & headers for selected binding.
+ *
+ * Parameters:
+ *  request_rec *r         The request we are processing.
+ *  LassoLogin *login      The login message.
+ *
+ * Returns:
+ *  HTTP response code
+ */
+static int am_set_authn_request_content(request_rec *r, LassoLogin *login)
+
+{
+    switch (login->http_method) {
     case LASSO_HTTP_METHOD_REDIRECT:
-        return am_send_authn_request_redirect(r, login);
+        return am_set_authn_request_redirect_content(r, login);
     case LASSO_HTTP_METHOD_POST:
-        return am_send_authn_request_post(r, login);
+        return am_set_authn_request_post_content(r, login);
+    case LASSO_HTTP_METHOD_PAOS:
+        return am_set_authn_request_paos_content(r, login);
     default:
         /* We should never get here. */
         ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
                       "Unsupported http_method.");
-        lasso_login_destroy(login);
         return HTTP_INTERNAL_SERVER_ERROR;
     }
+}
+
+#ifdef HAVE_ECP
+/* Build an IDPList whose members have an endpoint supporing
+ * the protocol_type and http_method.
+ */
+static LassoNode *
+am_get_idp_list(const LassoServer *server, LassoMdProtocolType protocol_type, LassoHttpMethod http_method)
+{
+    GList *idp_entity_ids = NULL;
+    GList *entity_id = NULL;
+    GList *idp_entries = NULL;
+    LassoSamlp2IDPList *idp_list;
+    LassoSamlp2IDPEntry *idp_entry;
+
+    idp_list = LASSO_SAMLP2_IDP_LIST(lasso_samlp2_idp_list_new());
+
+    idp_entity_ids =
+        lasso_server_get_filtered_provider_list(server,
+                                                LASSO_PROVIDER_ROLE_IDP,
+                                                protocol_type, http_method);
+
+    for (entity_id = g_list_first(idp_entity_ids); entity_id != NULL;
+         entity_id = g_list_next(entity_id)) {
+        idp_entry = LASSO_SAMLP2_IDP_ENTRY(lasso_samlp2_idp_entry_new());
+        idp_entry->ProviderID = g_strdup(entity_id->data);
+
+        /* RFE: we should have a mechanism to obtain these values */
+        idp_entry->Name = NULL;
+        idp_entry->Loc = NULL;
+
+        idp_entries = g_list_append(idp_entries, idp_entry);
+    }
+    lasso_release_list_of_strings(idp_entity_ids);
+
+    idp_list->IDPEntry = idp_entries;
+    return LASSO_NODE(idp_list);
+}
+
+/* Send AuthnRequest using PAOS binding.
+ *
+ * Parameters:
+ *  request_rec *r
+ *
+ * Returns:
+ *  OK on success, or an error on failure.
+ */
+static int am_send_paos_authn_request(request_rec *r)
+{
+    gint ret;
+    am_dir_cfg_rec *dir_cfg;
+    LassoServer *server;
+    LassoLogin *login;
+    const char *relay_state = NULL;
+    char *assertion_consumer_service_url;
+    int is_passive = FALSE;
+
+    dir_cfg = am_get_dir_cfg(r);
+
+    server = am_get_lasso_server(r);
+    if(server == NULL) {
+        return HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    relay_state = am_reconstruct_url(r);
+
+    assertion_consumer_service_url =
+        am_get_assertion_consumer_service_by_binding(LASSO_PROVIDER(server),
+                                                     "PAOS");
+
+    ret = am_init_authn_request_common(r, &login,
+                                       NULL, LASSO_HTTP_METHOD_PAOS, NULL,
+                                       assertion_consumer_service_url,
+                                       relay_state, is_passive);
+    g_free(assertion_consumer_service_url);
+
+    if (ret != OK) {
+        if (login) {
+            lasso_login_destroy(login);
+        }
+        return ret;
+    }
+
+    if (CFG_VALUE(dir_cfg, ecp_send_idplist)) {
+        lasso_profile_set_idp_list(LASSO_PROFILE(login),
+                                   am_get_idp_list(LASSO_PROFILE(login)->server,
+                                                   LASSO_MD_PROTOCOL_TYPE_SINGLE_SIGN_ON,
+                                                   LASSO_HTTP_METHOD_SOAP));
+    }
+
+    ret = am_set_authn_request_content(r, login);
+    lasso_login_destroy(login);
+
+    return ret;
+}
+#endif /* HAVE_ECP */
+
+/* Create and send an authentication request.
+ *
+ * Parameters:
+ *  request_rec *r         The request we are processing.
+ *  const char *idp        The entityID of the IdP.
+ *  const char *return_to  The URL we should redirect to when receiving the request.
+ *  int is_passive         The value of the IsPassive flag in <AuthnRequest>
+ *
+ * Returns:
+ *  HTTP response code indicating success or failure.
+ */
+static int am_send_login_authn_request(request_rec *r, const char *idp,
+                                 const char *return_to_url,
+                                 int is_passive)
+{
+    int ret;
+    LassoServer *server;
+    LassoProvider *provider;
+    LassoHttpMethod http_method;
+    char *destination_url;
+    char *assertion_consumer_service_url;
+    LassoLogin *login;
+
+    /* Add cookie for cookie test. We know that we should have
+     * a valid cookie when we return from the IdP after SP-initiated
+     * login.
+     */
+    am_cookie_set(r, "cookietest");
+
+    server = am_get_lasso_server(r);
+    if(server == NULL) {
+        return HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    /* Find our IdP. */
+    provider = lasso_server_get_provider(server, idp);
+    if (provider == NULL) {
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                      "Could not find metadata for the IdP \"%s\".",
+                      idp);
+        return HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    /* Determine what binding and endpoint we should use when
+     * sending the request.
+     */
+    http_method = LASSO_HTTP_METHOD_REDIRECT;
+    destination_url = lasso_provider_get_metadata_one(
+        provider, "SingleSignOnService HTTP-Redirect");
+    if (destination_url == NULL) {
+        /* HTTP-Redirect unsupported - try HTTP-POST. */
+        http_method = LASSO_HTTP_METHOD_POST;
+        destination_url = lasso_provider_get_metadata_one(
+            provider, "SingleSignOnService HTTP-POST");
+    }
+    if (destination_url == NULL) {
+        /* Both HTTP-Redirect and HTTP-POST unsupported - give up. */
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                      "Could not find a supported SingleSignOnService endpoint"
+                      " for the IdP \"%s\".", idp);
+        return HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    assertion_consumer_service_url =
+        lasso_provider_get_assertion_consumer_service_url(
+            LASSO_PROVIDER(server), NULL);
+
+    ret = am_init_authn_request_common(r, &login, idp, http_method,
+                                       destination_url,
+                                       assertion_consumer_service_url,
+                                       return_to_url, is_passive);
+
+    g_free(destination_url);
+    g_free(assertion_consumer_service_url);
+
+    if (ret != OK) {
+        if (login) {
+            lasso_login_destroy(login);
+        }
+        return ret;
+    }
+
+    ret = am_set_authn_request_content(r, login);
+    lasso_login_destroy(login);
+
+    return ret;
 }
 
 
@@ -2725,7 +3017,7 @@ static int am_handle_auth(request_rec *r)
             relay_state = return_url;
     }
 
-    return am_send_authn_request(r, am_get_idp(r), relay_state, FALSE);
+    return am_send_login_authn_request(r, am_get_idp(r), relay_state, FALSE);
 }
 
 /* This function handles requests to the login handler.
@@ -2742,7 +3034,6 @@ static int am_handle_login(request_rec *r)
     char *idp_param;
     const char *idp;
     char *return_to;
-    char *is_passive_str;
     int is_passive;
     int ret;
 
@@ -2770,25 +3061,9 @@ static int am_handle_login(request_rec *r)
         }
     }
 
-    is_passive_str = am_extract_query_parameter(r->pool, r->args, "IsPassive");
-    if(is_passive_str != NULL) {
-        ret = am_urldecode((char*)is_passive_str);
-        if(ret != OK) {
-            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
-                          "Error urldecoding IsPassive parameter.");
-            return ret;
-        }
-        if(!strcmp(is_passive_str, "true")) {
-            is_passive = TRUE;
-        } else if(!strcmp(is_passive_str, "false")) {
-            is_passive = FALSE;
-        } else {
-            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
-                          "Invalid value for IsPassive parameter - must be \"true\" or \"false\".");
-            return HTTP_BAD_REQUEST;
-        }
-    } else {
-        is_passive = FALSE;
+    ret = am_get_boolean_query_parameter(r, "IsPassive", &is_passive, FALSE);
+    if (ret != OK) {
+        return ret;
     }
 
     if(idp_param != NULL) {
@@ -2806,7 +3081,7 @@ static int am_handle_login(request_rec *r)
         idp = am_get_idp(r);
     }
 
-    return am_send_authn_request(r, idp, return_to, is_passive);
+    return am_send_login_authn_request(r, idp, return_to, is_passive);
 }
 
 /* This function probes an URL (HTTP GET)
@@ -2993,7 +3268,32 @@ static int am_handle_probe_discovery(request_rec *r) {
 int am_handler(request_rec *r)
 {
     am_dir_cfg_rec *cfg = am_get_dir_cfg(r);
+#ifdef HAVE_ECP
+    am_req_cfg_rec *req_cfg = am_get_req_cfg(r);
+#endif /* HAVE_ECP */
     const char *endpoint;
+
+    /*
+     * Normally this content handler is used to dispatch to the SAML
+     * endpoints implmented by mod_auth_mellon. SAML endpoint dispatch
+     * occurs when the URI begins with the SAML endpoint path.
+     *
+     * However, this handler is also responsible for generating ECP
+     * authn requests, in this case the URL will be a protected
+     * resource we're doing authtentication for. Early in the request
+     * processing pipeline we detected we were doing ECP authn and set
+     * a flag on the request. Here we test for that flag and if true
+     * respond with the ECP PAOS authn request.
+     *
+     * If the request is neither for a SAML endpoint nor one that
+     * requires generating an ECP authn we decline handling the request.
+     */
+
+#ifdef HAVE_ECP
+    if (req_cfg->ecp_authn_req) { /* Are we doing ECP? */
+        return am_send_paos_authn_request(r);
+    }
+#endif /* HAVE_ECP */
 
     /* Check if this is a request for one of our endpoints. We check if
      * the uri starts with the path set with the MellonEndpointPath
@@ -3011,6 +3311,8 @@ int am_handler(request_rec *r)
         return am_handle_post_reply(r);
     } else if(!strcmp(endpoint, "artifactResponse")) {
         return am_handle_artifact_reply(r);
+    } else if(!strcmp(endpoint, "paosResponse")) {
+        return am_handle_paos_reply(r);
     } else if(!strcmp(endpoint, "auth")) {
         return am_handle_auth(r);
     } else if(!strcmp(endpoint, "logout")
@@ -3127,8 +3429,31 @@ int am_auth_mellon_user(request_rec *r)
                 am_release_request_session(r, session);
             }
 
+#ifdef HAVE_ECP
+            /*
+             * If PAOS set a flag on the request indicating we're
+             * doing ECP and allow the request to proceed through the
+             * request handlers until we reach am_handler which then
+             * checks the flag and if True initiates an ECP transaction.
+             * See am_check_uid for detailed explanation.
+             */
+
+            if (am_is_paos_request(r)) {
+                am_req_cfg_rec *req_cfg;
+
+                req_cfg = am_get_req_cfg(r);
+                req_cfg->ecp_authn_req = true;
+
+                return OK;
+
+            } else {
+                /* Send the user to the authentication page on the IdP. */
+                return am_start_auth(r);
+            }
+#else /* HAVE_ECP */
             /* Send the user to the authentication page on the IdP. */
             return am_start_auth(r);
+#endif /* HAVE_ECP */
         }
 
         /* Verify that the user has access to this resource. */
@@ -3200,12 +3525,53 @@ int am_check_uid(request_rec *r)
         return OK;
     }
 
+#ifdef HAVE_ECP
+    am_req_cfg_rec *req_cfg = am_get_req_cfg(r);
+    if (req_cfg->ecp_authn_req) {
+        ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r,
+                      "am_check_uid is performing ECP authn request flow");
+        /*
+         * Normally when a protected resource requires authentication
+         * the request processing pipeline is exited early by
+         * responding with either a 401 or a redirect. But the flow
+         * for ECP is different, there will be a successful response
+         * (200) but instead of the response body containing the
+         * protected resource it will contain a SAML AuthnRequest
+         * with the Content-Type indicating it's PAOS ECP.
+         *
+         * In order to return a 200 Success with a PAOS body we have
+         * to reach the handler stage of the request processing
+         * pipeline. But this is a protected resource and we won't
+         * reach the handler stage unless authn and authz are
+         * satisfied. Therefore we lie and return results which
+         * indicate authn and authz are satisfied. This is OK because
+         * we're not actually going to respond with the protected
+         * resource, instead we'll be responsing with a SAML request.
+         *
+         * Apache's internal request logic
+         * (ap_process_request_internal) requires that after a
+         * successful return from the check_user_id authentication
+         * hook the r->user value be non-NULL. This makes sense
+         * because authentication establishes who the authenticated
+         * principal is. But with ECP flow there is no authenticated
+         * user at this point, we're just faking successful
+         * authentication in order to reach the handler stage. To get
+         * around this problem we set r-user to the empty string to
+         * keep Apache happy, otherwise it would throw an
+         * error. mod_shibboleth does the same thing.
+         */
+        r->user = "";
+        return OK;
+    }
+#endif /* HAVE_ECP */
+
     /* Check if this is a request for one of our endpoints. We check if
      * the uri starts with the path set with the MellonEndpointPath
      * configuration directive.
      */
     if(strstr(r->uri, dir->endpoint_path) == r->uri) {
         /* No access control on our internal endpoints. */
+        r->user = "";           /* see above explanation */
         return OK;
     }
 

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,8 @@ AC_CHECK_LIB(lasso, lasso_server_load_metadata,
              LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_lasso_server_load_metadata")
 AC_CHECK_LIB(lasso, lasso_profile_set_signature_verify_hint,
              LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_lasso_profile_set_signature_verify_hint")
+AC_CHECK_LIB(lasso, lasso_ecp_request_new,
+             LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_ECP")
 LIBS=$saved_LIBS;
 AC_SUBST(LASSO_CFLAGS)
 AC_SUBST(LASSO_LIBS)
@@ -71,6 +73,17 @@ AC_SUBST(OPENSSL_LIBS)
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.12])
 AC_SUBST(GLIB_CFLAGS)
 AC_SUBST(GLIB_LIBS)
+
+# Test to see if we can include lasso/utils.h
+# AC_CHECK_HEADER won't work correctly unless we specifiy the include directories
+# found in the LASSO_CFLAGS. Save and restore CFLAGS and CPPFLAGS.
+saved_CFLAGS=$CFLAGS
+saved_CPPFLAGS=$CPPFLAGS
+CFLAGS="$CFLAGS $pkg_cv_LASSO_CFLAGS"
+CPPFLAGS="$CPPFLAGS $pkg_cv_LASSO_CFLAGS"
+AC_CHECK_HEADER([lasso/utils.h], LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_LASSO_UTILS_H")
+CFLAGS=$saved_CFLAGS
+CPPFLAGS=$saved_CPPFLAGS
 
 
 # Create Makefile from Makefile.in

--- a/lasso_compat.h
+++ b/lasso_compat.h
@@ -1,0 +1,50 @@
+#ifdef HAVE_LASSO_UTILS_H
+
+#include <lasso/utils.h>
+
+#else
+
+#define lasso_assign_string(dest,src)           \
+{                                               \
+    char *__tmp = g_strdup(src);                \
+    lasso_release_string(dest);                 \
+    dest = __tmp;                               \
+}
+
+#define lasso_release_string(dest)              \
+	lasso_release_full(dest, g_free)
+
+#define lasso_release_full(dest, free_function) \
+{                                               \
+    if (dest) {                                 \
+        free_function(dest); dest = NULL;       \
+    }                                           \
+}
+
+#define lasso_check_type_equality(a,b)
+
+#define lasso_release_full2(dest, free_function, type)  \
+{                                                       \
+    lasso_check_type_equality(dest, type);              \
+    if (dest) {                                         \
+        free_function(dest); dest = NULL;               \
+    }                                                   \
+}
+
+#define lasso_release_list(dest)                        \
+	lasso_release_full2(dest, g_list_free, GList*)
+
+#define lasso_release_list_of_full(dest, free_function)         \
+{                                                               \
+    GList **__tmp = &(dest);                                    \
+    if (*__tmp) {                                               \
+        g_list_foreach(*__tmp, (GFunc)free_function, NULL);     \
+        lasso_release_list(*__tmp);                             \
+    }                                                           \
+}
+
+#define lasso_release_list_of_strings(dest)     \
+	lasso_release_list_of_full(dest, g_free)
+
+
+#endif

--- a/mod_auth_mellon.c
+++ b/mod_auth_mellon.c
@@ -182,12 +182,30 @@ static void am_child_init(apr_pool_t *p, server_rec *s)
 }
 
 
+static int am_create_request(request_rec *r)
+{
+    am_req_cfg_rec *req_cfg;
+
+    req_cfg = apr_pcalloc(r->pool, sizeof(am_req_cfg_rec));
+
+    req_cfg->cookie_value = NULL;
+#ifdef HAVE_ECP
+    req_cfg->ecp_authn_req = false;
+#endif /* HAVE_ECP */
+
+    ap_set_module_config(r->request_config, &auth_mellon_module, req_cfg);
+
+    return OK;
+}
+
+
 static void register_hooks(apr_pool_t *p)
 {
     ap_hook_access_checker(am_auth_mellon_user, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_check_user_id(am_check_uid, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_post_config(am_global_init, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_child_init(am_child_init, NULL, NULL, APR_HOOK_MIDDLE);
+    ap_hook_create_request(am_create_request, NULL, NULL, APR_HOOK_MIDDLE);
 
     /* Add the hook to handle requests to the mod_auth_mellon endpoint.
      *


### PR DESCRIPTION
The modifications in this commit address the changes necessary to
support the SP component of SAML ECP. The Lasso library needs
additional modifications before SAML ECP will be fully functional,
those fixes have been submitted to upstream Lasso, mod_auth_mellon
will continue to operate correctly without the Lasso upgrade, it just
won't properly support ECP without the Lasso fixes.

Below are the major logical changes in the commit and the rationale
behind them.

* Allow compilation against older versions of Lasso by conditionally
  compiling.

  Add the following CPP symbols set by configure:

  * HAVE_ECP
  * HAVE_LASSO_UTILS_H

* Add lasso_compat.h

  If we can't include lasso utils.h than pull in our own
  local definitions so we can use some of the valuable
  utilities.

* Add ECP specific documentation file

  Documentation specific to ECP is now contained in ECP.rst
  (using reStructuredText formatting). Information on general ECP
  concepts, mod_auth_mellon user information, and internal
  mod_auth_mellon coding issues are covered.

* Add am_get_boolean_query_parameter() utility

* Add am_validate_paos_header() utility

  This utility routine validates the PAOS HTTP header. It is used
  in conjunction with am_header_has_media_type() to determine if a
  client is ECP capable.

* Add am_is_paos_request() utility

  This utility checks to see if the request is PAOS based on the
  required HTTP header content.

* Add utility function am_header_has_media_type() to check if an HTTP
  Accept header includes a specific media type. This is necessary
  because the SP detects an ECP client by the presence of a
  application/vnd.paos+xml media type in the Accept
  header. Unfortunately neither Apache nor mod_auth_mellon already had
  a function to check Accept media types so this was custom written
  and added to mod_auth_mellon.

* Add utility function am_get_assertion_consumer_service_by_binding()
  because Lasso does not expose that in it's public API. It's
  necessary to get the URL of the PAOS AssertionConsumerService.

* Add MellonECPSendIDPList config option

  This option controls whether to include a list of IDP's when
  sending an ECP PAOS <AuthnRequest> message to an ECP client.

* We need to do some bookkeeping during the processing of a
  request. Some Apache modules call this "adding a
  note". mod_auth_mellon was already doing this but because it only
  needed to track one value (the cookie value) took a shortcut and
  stuffed the cookie value into the per module request slot rather
  than defining a struct that could hold a variety of per-request
  values. To accommodate multiple per request bookkeeping values we
  define a new struct, am_req_cfg_rec, that holds the previously used
  cookie value and adds a new ECP specific value. This struct is now
  the bookkeeping data item attached to each request. To support the
  new am_req_cfg_rec struct the am_get_req_cfg macro was added (mirrors
  the existing am_get_srv_cfg, am_get_mod_cfg and am_get_dir_cfg
  macros). The am_create_request() Apache hook was added to
  initialize the am_req_cfg_rec at the beginning of the request
  pipeline.

* A new endpoint was added to handle PAOS responses from the ECP
  client. The endpoint is called "paosResponse" and lives along side
  of the existing endpoints (e.g. postResponse, artifactResponse,
  metadata, auth, logout, etc.). The new endpoint is handled by
  am_handle_paos_reply(). The metadata generation implemented in
  am_generate_metadata() was augmented to add the paosResponse
  endpoint and bind it to the SAML2 PAOS binding.

* am_handle_reply_common() was being called by am_handle_post_reply()
  and am_handle_artifact_reply() because replies share a fair amount
  of common logic. The new am_handle_paos_reply() also needs to
  utilize the same common logic in am_handle_reply_common() but ECP
  has slightly different behavior that has to be accounted for. With
  ECP there is no SP generated cookie because the SP did not initiate
  the process and has no state to track. Also the RelayState is
  optional with ECP and is carried in the PAOS header as opposed to an
  HTTP query/post parameter. The boolean flag is_paos was added as a
  parameter to am_handle_reply_common() so as to be able to
  distinguish between the PAOS and non-PAOS logic.

* Add PAOS AssertionConsumerService to automatically generated metadata.
  Note, am_get_assertion_consumer_service_by_binding() should be able
  to locate this endpoint.

* Refactor code to send <AuthnRequest>, now also supports PAOS

  The creation and initialization of a LassoLogin object is different
  for the ECP case. We want to share as much common code as possible,
  the following refactoring was done to achieve that goal.

  The function am_send_authn_request() was removed and it's logic
  moved to am_init_authn_request_common(),
  am_send_login_authn_request() and
  am_set_authn_request_content(). This allows the logic used to create
  and initialize a LassoLogin object to be shared between the PAOS and
  non-PAOS cases. am_send_paos_authn_request() also calls
  am_init_authn_request_common() and
  am_set_authn_request_content(). The function
  am_set_authn_request_content() replaces the logic at the end of
  am_send_authn_request(), it is responsible for setting the HTTP
  headers and body content based on the LassoLogin.

Signed-off-by: John Dennis <jdennis@redhat.com>