### PR TITLE
Role maybe unknown when assertion consumer url is looked up

### DIFF
--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -1827,7 +1827,9 @@ char *am_get_assertion_consumer_service_by_binding(LassoProvider *provider, cons
     }
 
     if (selected_descriptor) {
-        url = lasso_provider_get_metadata_one(provider, selected_descriptor);
+        url = lasso_provider_get_metadata_one_for_role(provider,
+                                                       LASSO_PROVIDER_ROLE_SP,
+                                                       selected_descriptor);
     }
 
     lasso_release_list_of_strings(descriptors);


### PR DESCRIPTION
Replace the call to lasso_provider_get_metadata_one() with
lasso_provider_get_metadata_one_for_role() so that we can exlicitly
pass the LASSO_PROVIDER_ROLE_SP role. The former call obtains the
role from the provider object and then calls
lasso_provider_get_metadata_one_for_role() using that role. However
the role will not have been set in the provider until the first request is
processed. This means the first time we call this routine it won't
work correctly because the role will not have been set yet, by
explicitly passing the role we avoid this problem.

Signed-off-by: John Dennis <jdennis@redhat.com>