### PR TITLE
Check build warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ env:
 install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq "$APACHE_PKG" libglib2.0-dev liblasso3-dev libssl-dev
-script: ./autogen.sh && ./configure && make && make distfile
+script: ./autogen.sh && ./configure CFLAGS=-Werror && make && make distfile

--- a/Makefile.in
+++ b/Makefile.in
@@ -25,7 +25,7 @@ DISTFILES=$(SRC) \
 all:	mod_auth_mellon.la
 
 mod_auth_mellon.la: $(SRC) auth_mellon.h auth_mellon_compat.h
-	@APXS2@ -Wc,"-std=c99 @OPENSSL_CFLAGS@ @LASSO_CFLAGS@ @CURL_CFLAGS@ @GLIB_CFLAGS@" -Wl,"@OPENSSL_LIBS@ @LASSO_LIBS@ @CURL_LIBS@ @GLIB_LIBS@" -Wc,-Wall -Wc,-g -c $(SRC)
+	@APXS2@ -Wc,"-std=c99 @OPENSSL_CFLAGS@ @LASSO_CFLAGS@ @CURL_CFLAGS@ @GLIB_CFLAGS@ @CFLAGS@" -Wl,"@OPENSSL_LIBS@ @LASSO_LIBS@ @CURL_LIBS@ @GLIB_LIBS@" -Wc,-Wall -Wc,-g -c $(SRC)
 
 
 # Building configure (for distribution)


### PR DESCRIPTION
We don't want to miss build warnings that have security implications, so add the `-Werror` option to the Travis build. We may have to revisit it in the future, but I think it is a good start.
