### PR TITLE
Allow separate configuration of mellon cookie 'HttpOnly' and 'secure' flags.

### DIFF
--- a/README
+++ b/README
@@ -180,8 +180,9 @@ MellonPostCount 100
         # Default: "cookie"
         MellonVariable "cookie"
 
-        # MellonSecureCookie enforces the HttpOnly and secure flags
-        # for the mod_mellon cookie
+        # Whether the cookie set by auth_mellon should have HttpOnly and
+        # secure flags set. Once "On" - both flags will be set. Values 
+        # "httponly" or "secure" will respectively set only one flag.
         # Default: Off
         MellonSecureCookie On
 

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -173,6 +173,7 @@ typedef struct am_dir_cfg_rec {
 
     const char *varname;
     int secure;
+    int http_only;
     const char *merge_env_vars;
     int env_vars_index_start;
     int env_vars_count_in_n;

--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -52,6 +52,7 @@ static const char *am_cookie_name(request_rec *r)
 static const char *am_cookie_params(request_rec *r)
 {
     int secure_cookie;
+    int http_only_cookie;
     const char *cookie_domain = ap_get_server_name(r);
     const char *cookie_path = "/";
     am_dir_cfg_rec *cfg = am_get_dir_cfg(r);
@@ -65,11 +66,13 @@ static const char *am_cookie_params(request_rec *r)
     }
 
     secure_cookie = cfg->secure;
+    http_only_cookie = cfg->http_only;
 
     return apr_psprintf(r->pool,
-                        "Version=1; Path=%s; Domain=%s%s;",
+                        "Version=1; Path=%s; Domain=%s%s%s;",
                         cookie_path, cookie_domain,
-                        secure_cookie ? "; HttpOnly; secure" : "");
+                        http_only_cookie ? "; HttpOnly" : "",
+                        secure_cookie ? "; secure" : "");
 }
 
 


### PR DESCRIPTION
Introduce new values for MellonSecureCookie configuration option:
'secure' and 'httponly' for setting just one particular cookie flag. Old
'On' and 'Off' values remain supported and behave the same way as
before.