### PR TITLE
am_check_permissions() failure should return HTTP_FORBIDDEN

### DIFF
--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -3694,7 +3694,7 @@ int am_check_uid(request_rec *r)
     return_code = am_check_permissions(r, session);
     if(return_code != OK) {
         am_release_request_session(r, session);
-        return HTTP_UNAUTHORIZED;
+        return return_code;
     }
 
     /* The user has been authenticated, and we can now populate r->user


### PR DESCRIPTION
In am_check_uid() if am_check_permissions() denies access then the
proper HTTP return code is FORBIDDEN (which is what
am_check_permissions() returns on failure). Returning the result of
am_check_permissions() is what is already done in
am_auth_mellon_user(), this just makes the behavior
consistent. Returning UNAUTHORIZED is clearly wrong, that is meant to
indicate authentication needs to be performed.

Signed-off-by: John Dennis <jdennis@redhat.com>