### PR TITLE
Fix Content-Type, should be "text/xml" not "application/soap+xml"

### DIFF
--- a/ECP.rst
+++ b/ECP.rst
@@ -140,7 +140,7 @@ operations.
   response = session.post(ecp.msgUrl,
                           data=ecp.msgBody,
                           auth=requests.auth.HTTPDigestAuth(user, password)
-                          headers={'Content-Type': 'application/soap+xml'})
+                          headers={'Content-Type': 'text/xml'})
 
   # Process returned SOAP wrapped <Assertion> from IdP
   ecp.processResponseMsg(response.text)


### PR DESCRIPTION
There was an error in the example for POST'ing the the AuthnRequest to
the IdP, the Content-Type header erroneously was
"application/soap+xml" when in fact it should have been "text/xml".

As background the Content-Type for SOAP 1.1 is "text/xml" but in SOAP
1.2 it was changed to "application/soap+xml". ECP is specificed to
used SOAP 1.1.

Signed-off-by: John Dennis <jdennis@redhat.com>