### PR TITLE
Fix unit on MellonPostSize description

### DIFF
--- a/README
+++ b/README
@@ -125,8 +125,8 @@ MellonLockFile "/var/run/mod_auth_mellon.lock"
 MellonPostTTL 900
 
 # MellonPostSize is the maximum size for saved POST requests
-# Default: MellonPostSize 1073741824 (1 GB)
-MellonPostSize 1073741824
+# Default: MellonPostSize 1048576 (1 MB)
+MellonPostSize 1048576
 
 # MellonPostCount is the maximum amount of saved POST requests
 # Default: MellonPostCount 100

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -1034,7 +1034,7 @@ const command_rec auth_mellon_commands[] = {
         (void *)APR_OFFSETOF(am_mod_cfg_rec, post_size),
         RSRC_CONF,
         "The maximum size of a saved POST, in bytes."
-        " Default value is 1 MB."
+        " Default value is 1 GB."
         ), 
 
 

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -67,7 +67,7 @@ static const apr_time_t post_ttl = 15 * 60;
 /* saved POST session maximum size
  * the MellonPostSize configuration directive if you change this.
  */
-static const apr_size_t post_size = 1024 * 1024 * 1024;
+static const apr_size_t post_size = 1024 * 1024;
 
 /* maximum saved POST sessions
  * the MellonPostCount configuration directive if you change this.
@@ -1034,7 +1034,7 @@ const command_rec auth_mellon_commands[] = {
         (void *)APR_OFFSETOF(am_mod_cfg_rec, post_size),
         RSRC_CONF,
         "The maximum size of a saved POST, in bytes."
-        " Default value is 1 GB."
+        " Default value is 1 MB."
         ), 
 
 


### PR DESCRIPTION
Noticed the default value on this was 1024 * 1024 * 1024 bytes (1 GB) but the description text says the default value is 1 MB.