### PR TITLE
Use ap_strcasestr instead of strcasestr for improved POSIX compatibility

### DIFF
--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -448,7 +448,7 @@ int am_check_permissions(request_rec *r, am_cache_entry_t *session)
                  match = !ap_regexec(ce->regex, value, 0, NULL, 0);
 
             } else if (ce->flags & (AM_COND_FLAG_SUB|AM_COND_FLAG_NC)) {
-                 match = (strcasestr(ce->str, value) != NULL);
+                 match = (ap_strcasestr(ce->str, value) != NULL);
 
             } else if (ce->flags & AM_COND_FLAG_SUB) {
                  match = (strstr(ce->str, value) != NULL);


### PR DESCRIPTION
Some platforms, e.g. Solaris, do not have strcasestr(). Apache brings ap_strcasestr() since version 2.0.0.