### PR TITLE
Support Apache 2.4 per module log level.

### DIFF
--- a/auth_mellon_cache.c
+++ b/auth_mellon_cache.c
@@ -21,6 +21,10 @@
 
 #include "auth_mellon.h"
 
+#ifdef APLOG_USE_MODULE
+APLOG_USE_MODULE(auth_mellon);
+#endif
+
 /* Calculate the pointer to a cache entry.
  *
  * Parameters:

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -21,6 +21,10 @@
 
 #include "auth_mellon.h"
 
+#ifdef APLOG_USE_MODULE
+APLOG_USE_MODULE(auth_mellon);
+#endif
+
 /* This is the default endpoint path. Remember to update the description of
  * the MellonEndpointPath configuration directive if you change this.
  */

--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -21,6 +21,9 @@
 
 #include "auth_mellon.h"
 
+#ifdef APLOG_USE_MODULE
+APLOG_USE_MODULE(auth_mellon);
+#endif
 
 /* This function retrieves the name of our cookie.
  *

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -19,9 +19,11 @@
  *
  */
 
-
 #include "auth_mellon.h"
 
+#ifdef APLOG_USE_MODULE
+APLOG_USE_MODULE(auth_mellon);
+#endif
 
 /*
  * Note:

--- a/auth_mellon_httpclient.c
+++ b/auth_mellon_httpclient.c
@@ -19,15 +19,16 @@
  *
  */
 
-
 #include "auth_mellon.h"
 
 #include <curl/curl.h>
 
-
 /* The size of the blocks we will allocate. */
 #define AM_HC_BLOCK_SIZE 1000
 
+#ifdef APLOG_USE_MODULE
+APLOG_USE_MODULE(auth_mellon);
+#endif
 
 /* This structure describes a single-linked list of downloaded blocks. */
 typedef struct am_hc_block_s {

--- a/auth_mellon_session.c
+++ b/auth_mellon_session.c
@@ -21,6 +21,9 @@
 
 #include "auth_mellon.h"
 
+#ifdef APLOG_USE_MODULE
+APLOG_USE_MODULE(auth_mellon);
+#endif
 
 /* This function gets the session associated with a user, using a cookie
  *

--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -26,6 +26,10 @@
 
 #include "auth_mellon.h"
 
+#ifdef APLOG_USE_MODULE
+APLOG_USE_MODULE(auth_mellon);
+#endif
+
 /* This function is used to get the url of the current request.
  *
  * Parameters:

--- a/mod_auth_mellon.c
+++ b/mod_auth_mellon.c
@@ -19,10 +19,13 @@
  *
  */
 
-
 #include "auth_mellon.h"
 
 #include <curl/curl.h>
+
+#ifdef APLOG_USE_MODULE
+APLOG_USE_MODULE(auth_mellon);
+#endif
 
 /* This function is called after the configuration of the server is parsed
  * (it's a post-config hook).


### PR DESCRIPTION
Use APLOG_USE_MODULE if available.
This will also add the module name to its error log messages,
e.g. "[auth_mellon:error]" instead of just "[:error]".

No change for Apache 2.2.