### PR TITLE
Consistent lasso error reporting.

### DIFF
--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -285,8 +285,8 @@ static guint am_server_add_providers(am_dir_cfg_rec *cfg, request_rec *r)
         if (error != 0) {
             ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
                           "Error adding metadata \"%s\" to "
-                          "lasso server objects: %s.",
-                          idp_metadata->file, lasso_strerror(error));
+                          "lasso server objects. Lasso error: [%i] %s",
+                          idp_metadata->file, error, lasso_strerror(error));
         }
     }
 


### PR DESCRIPTION
All other log messages containing lasso errors already use the idiom
    Some message. Lasso error: [%i] %s", ..., rc, lasso_strerror(rc)
The different log format here leads e.g. to a double "." at the
end of the log message. Example:
    Error adding metadata "/path/to/idp-metadata.xml" to lasso
    server objects: Parsed XML is invalid..