### PR TITLE
Adds support for the SameSite cookie attribute

### DIFF
--- a/README
+++ b/README
@@ -197,6 +197,13 @@ MellonPostCount 100
         # Default: /
         MellonCookiePath /
 
+        # MellonCookieSameSite allows control over the SameSite value used
+        # for the authentication cookie.
+        # The setting accepts values of "Strict" or "Lax"
+        # If not set, the SameSite attribute is not set on the cookie.
+        # Default: not set
+        # MellonCookieSameSite lax
+
         # MellonUser selects which attribute we should use for the username.
         # The username is passed on to other apache modules and to the web
         # page the user visits. NAME_ID is an attribute which we set to

--- a/README
+++ b/README
@@ -542,6 +542,11 @@ MellonPostCount 100
         # sending an ECP PAOS <AuthnRequest> message to an ECP client.
         MellonECPSendIDPList Off
 
+        # This option controls whether the Cache-control header is sent
+        # back in responses.
+        # Default: On
+        # MellonSendCacheControlHeader Off
+
         # List of domains that we allow redirects to.
         # The special name "[self]" means the domain of the current request.
         # The domain names can also use wildcards.

--- a/README
+++ b/README
@@ -197,13 +197,6 @@ MellonPostCount 100
         # Default: /
         MellonCookiePath /
 
-        # MellonCookieSameSite allows control over the SameSite value used
-        # for the authentication cookie.
-        # The setting accepts values of "Strict" or "Lax"
-        # If not set, the SameSite attribute is not set on the cookie.
-        # Default: not set
-        # MellonCookieSameSite lax
-
         # MellonUser selects which attribute we should use for the username.
         # The username is passed on to other apache modules and to the web
         # page the user visits. NAME_ID is an attribute which we set to

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -179,6 +179,7 @@ typedef struct am_dir_cfg_rec {
     int env_vars_count_in_n;
     const char *cookie_domain;
     const char *cookie_path;
+    const char *cookie_samesite;
     apr_array_header_t *cond;
     apr_hash_t *envattr;
     const char *userattr;

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -233,10 +233,15 @@ typedef struct am_dir_cfg_rec {
 
     /* AuthnContextClassRef list */
     apr_array_header_t *authn_context_class_ref;
+
     /* Controls the checking of SubjectConfirmationData.Address attribute */
     int subject_confirmation_data_address_check;
+
     /* MellonDoNotVerifyLogoutSignature idp set */
     apr_hash_t *do_not_verify_logout_signature;
+
+    /* Controls whether the cache control header is set */
+    int send_cache_control_header;
 
     /* Whether we should replay POST data after authentication. */
     int post_replay;
@@ -339,6 +344,11 @@ extern const am_error_map_t auth_mellon_errormap[];
  */
 static const int default_subject_confirmation_data_address_check = 1;
 static const int inherit_subject_confirmation_data_address_check = -1;
+
+/** Default values for seting the cache-control header
+ */
+static const int default_send_cache_control_header = 1;
+static const int inherit_send_cache_control_header = -1;
 
 /* Default and inherit values for MellonPostReplay option. */
 static const int default_post_replay = 0;

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -179,7 +179,6 @@ typedef struct am_dir_cfg_rec {
     int env_vars_count_in_n;
     const char *cookie_domain;
     const char *cookie_path;
-    const char *cookie_samesite;
     apr_array_header_t *cond;
     apr_hash_t *envattr;
     const char *userattr;

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -1340,6 +1340,13 @@ const command_rec auth_mellon_commands[] = {
         OR_AUTHCFG,
         "Check address given in SubjectConfirmationData Address attribute. Default is on."
         ),
+    AP_INIT_FLAG(
+        "MellonSendCacheControlHeader",
+        ap_set_flag_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, send_cache_control_header),
+        OR_AUTHCFG,
+        "Send the cache-control header on responses. Default is on."
+        ),
     AP_INIT_TAKE1(
         "MellonDoNotVerifyLogoutSignature",
         am_set_do_not_verify_logout_signature,
@@ -1488,6 +1495,7 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->server = NULL;
     dir->authn_context_class_ref = apr_array_make(p, 0, sizeof(char *));
     dir->subject_confirmation_data_address_check = inherit_subject_confirmation_data_address_check;
+    dir->send_cache_control_header = inherit_send_cache_control_header;
     dir->do_not_verify_logout_signature = apr_hash_make(p);
     dir->post_replay = inherit_post_replay;
     dir->redirect_domains = default_redirect_domains;
@@ -1729,6 +1737,10 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
 
     new_cfg->subject_confirmation_data_address_check =
         CFG_MERGE(add_cfg, base_cfg, subject_confirmation_data_address_check);
+
+    new_cfg->send_cache_control_header =
+        CFG_MERGE(add_cfg, base_cfg, send_cache_control_header);
+
     new_cfg->post_replay = CFG_MERGE(add_cfg, base_cfg, post_replay);
 
     new_cfg->ecp_send_idplist = CFG_MERGE(add_cfg, base_cfg, ecp_send_idplist);

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -1099,14 +1099,6 @@ const command_rec auth_mellon_commands[] = {
         " '/'."
         ),
     AP_INIT_TAKE1(
-        "MellonCookieSameSite",
-        ap_set_string_slot,
-        (void *)APR_OFFSETOF(am_dir_cfg_rec, cookie_samesite),
-        OR_AUTHCFG,
-        "The SameSite value for the auth_mellon cookie. Defaults to"
-        " having no SameSite value. Accepts values of Lax or Strict."
-        ),
-    AP_INIT_TAKE1(
         "MellonUser",
         ap_set_string_slot,
         (void *)APR_OFFSETOF(am_dir_cfg_rec, userattr),
@@ -1459,7 +1451,6 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->cond = apr_array_make(p, 0, sizeof(am_cond_t));
     dir->cookie_domain = NULL;
     dir->cookie_path = NULL;
-    dir->cookie_samesite = NULL;
     dir->envattr   = apr_hash_make(p);
     dir->userattr  = default_user_attribute;
     dir->idpattr  = NULL;
@@ -1599,10 +1590,6 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
     new_cfg->cookie_path = (add_cfg->cookie_path != NULL ?
                         add_cfg->cookie_path :
                         base_cfg->cookie_path);
-
-    new_cfg->cookie_samesite = (add_cfg->cookie_samesite != NULL ?
-                        add_cfg->cookie_samesite :
-                        base_cfg->cookie_samesite);
 
     new_cfg->cond = apr_array_copy(p,
                                    (!apr_is_empty_array(add_cfg->cond)) ?

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -1099,6 +1099,14 @@ const command_rec auth_mellon_commands[] = {
         " '/'."
         ),
     AP_INIT_TAKE1(
+        "MellonCookieSameSite",
+        ap_set_string_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, cookie_samesite),
+        OR_AUTHCFG,
+        "The SameSite value for the auth_mellon cookie. Defaults to"
+        " having no SameSite value. Accepts values of Lax or Strict."
+        ),
+    AP_INIT_TAKE1(
         "MellonUser",
         ap_set_string_slot,
         (void *)APR_OFFSETOF(am_dir_cfg_rec, userattr),
@@ -1444,6 +1452,7 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->cond = apr_array_make(p, 0, sizeof(am_cond_t));
     dir->cookie_domain = NULL;
     dir->cookie_path = NULL;
+    dir->cookie_samesite = NULL;
     dir->envattr   = apr_hash_make(p);
     dir->userattr  = default_user_attribute;
     dir->idpattr  = NULL;
@@ -1582,6 +1591,10 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
     new_cfg->cookie_path = (add_cfg->cookie_path != NULL ?
                         add_cfg->cookie_path :
                         base_cfg->cookie_path);
+
+    new_cfg->cookie_samesite = (add_cfg->cookie_samesite != NULL ?
+                        add_cfg->cookie_samesite :
+                        base_cfg->cookie_samesite);
 
     new_cfg->cond = apr_array_copy(p,
                                    (!apr_is_empty_array(add_cfg->cond)) ?

--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -58,6 +58,7 @@ static const char *am_cookie_params(request_rec *r)
     int http_only_cookie;
     const char *cookie_domain = ap_get_server_name(r);
     const char *cookie_path = "/";
+    const char *cookie_samesite = "";
     am_dir_cfg_rec *cfg = am_get_dir_cfg(r);
 
     if (cfg->cookie_domain) {
@@ -68,14 +69,23 @@ static const char *am_cookie_params(request_rec *r)
         cookie_path = cfg->cookie_path;
     }
 
+    if (cfg->cookie_samesite) {
+        if (strcasecmp("lax", cfg->cookie_samesite) == 0) {
+            cookie_samesite = "; SameSite=Lax";
+        } else if (strcasecmp("strict", cfg->cookie_samesite) == 0) {
+            cookie_samesite = "; SameSite=Strict";
+        }
+    }
+
     secure_cookie = cfg->secure;
     http_only_cookie = cfg->http_only;
 
     return apr_psprintf(r->pool,
-                        "Version=1; Path=%s; Domain=%s%s%s;",
+                        "Version=1; Path=%s; Domain=%s%s%s%s;",
                         cookie_path, cookie_domain,
                         http_only_cookie ? "; HttpOnly" : "",
-                        secure_cookie ? "; secure" : "");
+                        secure_cookie ? "; secure" : "",
+                        cookie_samesite);
 }
 
 

--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -58,7 +58,6 @@ static const char *am_cookie_params(request_rec *r)
     int http_only_cookie;
     const char *cookie_domain = ap_get_server_name(r);
     const char *cookie_path = "/";
-    const char *cookie_samesite = "";
     am_dir_cfg_rec *cfg = am_get_dir_cfg(r);
 
     if (cfg->cookie_domain) {
@@ -69,23 +68,14 @@ static const char *am_cookie_params(request_rec *r)
         cookie_path = cfg->cookie_path;
     }
 
-    if (cfg->cookie_samesite) {
-        if (strcasecmp("lax", cfg->cookie_samesite) == 0) {
-            cookie_samesite = "; SameSite=Lax";
-        } else if (strcasecmp("strict", cfg->cookie_samesite) == 0) {
-            cookie_samesite = "; SameSite=Strict";
-        }
-    }
-
     secure_cookie = cfg->secure;
     http_only_cookie = cfg->http_only;
 
     return apr_psprintf(r->pool,
-                        "Version=1; Path=%s; Domain=%s%s%s%s;",
+                        "Version=1; Path=%s; Domain=%s%s%s;",
                         cookie_path, cookie_domain,
                         http_only_cookie ? "; HttpOnly" : "",
-                        secure_cookie ? "; secure" : "",
-                        cookie_samesite);
+                        secure_cookie ? "; secure" : "");
 }
 
 

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -3506,7 +3506,9 @@ int am_auth_mellon_user(request_rec *r)
     }
 
     /* Set defaut Cache-Control headers within this location */
-    am_set_cache_control_headers(r);
+    if (CFG_VALUE(dir, send_cache_control_header)) {
+        am_set_cache_control_headers(r);
+    }
 
     /* Check if this is a request for one of our endpoints. We check if
      * the uri starts with the path set with the MellonEndpointPath


### PR DESCRIPTION
There is a draft update to RFC6265 to add the "SameSite" attribute to cookie. This attribute controls whether a cookie is presented to a server based on the origin of the request.

This update adds a MellonCookieSameSite configuration directive that can be used to control this value on the Mellon authentication cookie.

See:

- https://tools.ietf.org/html/draft-west-first-party-cookies-07
- https://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/

Cheers
Vittal