### PR TITLE
Adds the MellonSendCacheControlHeader to control the cache-control he…

### DIFF
--- a/README
+++ b/README
@@ -535,6 +535,11 @@ MellonPostCount 100
         # sending an ECP PAOS <AuthnRequest> message to an ECP client.
         MellonECPSendIDPList Off
 
+        # This option controls whether the Cache-control header is sent
+        # back in responses.
+        # Default: On
+        # MellonSendCacheControlHeader Off
+
         # List of domains that we allow redirects to.
         # The special name "[self]" means the domain of the current request.
         # The domain names can also use wildcards.

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -232,10 +232,15 @@ typedef struct am_dir_cfg_rec {
 
     /* AuthnContextClassRef list */
     apr_array_header_t *authn_context_class_ref;
+
     /* Controls the checking of SubjectConfirmationData.Address attribute */
     int subject_confirmation_data_address_check;
+
     /* MellonDoNotVerifyLogoutSignature idp set */
     apr_hash_t *do_not_verify_logout_signature;
+
+    /* Controls whether the cache control header is set */
+    int send_cache_control_header;
 
     /* Whether we should replay POST data after authentication. */
     int post_replay;
@@ -338,6 +343,11 @@ extern const am_error_map_t auth_mellon_errormap[];
  */
 static const int default_subject_confirmation_data_address_check = 1;
 static const int inherit_subject_confirmation_data_address_check = -1;
+
+/** Default values for seting the cache-control header
+ */
+static const int default_send_cache_control_header = 1;
+static const int inherit_send_cache_control_header = -1;
 
 /* Default and inherit values for MellonPostReplay option. */
 static const int default_post_replay = 0;

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -1332,6 +1332,13 @@ const command_rec auth_mellon_commands[] = {
         OR_AUTHCFG,
         "Check address given in SubjectConfirmationData Address attribute. Default is on."
         ),
+    AP_INIT_FLAG(
+        "MellonSendCacheControlHeader",
+        ap_set_flag_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, send_cache_control_header),
+        OR_AUTHCFG,
+        "Send the cache-control header on responses. Default is on."
+        ),
     AP_INIT_TAKE1(
         "MellonDoNotVerifyLogoutSignature",
         am_set_do_not_verify_logout_signature,
@@ -1479,6 +1486,7 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->server = NULL;
     dir->authn_context_class_ref = apr_array_make(p, 0, sizeof(char *));
     dir->subject_confirmation_data_address_check = inherit_subject_confirmation_data_address_check;
+    dir->send_cache_control_header = inherit_send_cache_control_header;
     dir->do_not_verify_logout_signature = apr_hash_make(p);
     dir->post_replay = inherit_post_replay;
     dir->redirect_domains = default_redirect_domains;
@@ -1716,6 +1724,10 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
 
     new_cfg->subject_confirmation_data_address_check =
         CFG_MERGE(add_cfg, base_cfg, subject_confirmation_data_address_check);
+
+    new_cfg->send_cache_control_header =
+        CFG_MERGE(add_cfg, base_cfg, send_cache_control_header);
+
     new_cfg->post_replay = CFG_MERGE(add_cfg, base_cfg, post_replay);
 
     new_cfg->ecp_send_idplist = CFG_MERGE(add_cfg, base_cfg, ecp_send_idplist);

--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -3506,7 +3506,9 @@ int am_auth_mellon_user(request_rec *r)
     }
 
     /* Set defaut Cache-Control headers within this location */
-    am_set_cache_control_headers(r);
+    if (CFG_VALUE(dir, send_cache_control_header)) {
+        am_set_cache_control_headers(r);
+    }
 
     /* Check if this is a request for one of our endpoints. We check if
      * the uri starts with the path set with the MellonEndpointPath


### PR DESCRIPTION
https://github.com/UNINETT/mod_auth_mellon/issues/2 raises the issue
of the Cache-Control header always being set, but with some users
needing to turn it off.

This update adds the MellonSendCacheControlHeader configuration
directive which can be set to Off, resulting in the cache-control
header not being set.