### PR TITLE
Rework the MellonCookieSameSite configuration to provide a custom parser

### DIFF
--- a/README
+++ b/README
@@ -197,6 +197,13 @@ MellonPostCount 100
         # Default: /
         MellonCookiePath /
 
+        # MellonCookieSameSite allows control over the SameSite value used
+        # for the authentication cookie.
+        # The setting accepts values of "Strict" or "Lax"
+        # If not set, the SameSite attribute is not set on the cookie.
+        # Default: not set
+        # MellonCookieSameSite lax
+
         # MellonUser selects which attribute we should use for the username.
         # The username is passed on to other apache modules and to the web
         # page the user visits. NAME_ID is an attribute which we set to

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -136,6 +136,12 @@ typedef enum {
 } am_enable_t;
 
 typedef enum {
+  am_samesite_default,
+  am_samesite_lax,
+  am_samesite_strict
+} am_samesite_t;
+
+typedef enum {
     AM_COND_FLAG_NULL = 0x000, /* No flags */
     AM_COND_FLAG_OR   = 0x001, /* Or with  next condition */
     AM_COND_FLAG_NOT  = 0x002, /* Negate this condition */
@@ -179,6 +185,7 @@ typedef struct am_dir_cfg_rec {
     int env_vars_count_in_n;
     const char *cookie_domain;
     const char *cookie_path;
+    am_samesite_t cookie_samesite;
     apr_array_header_t *cond;
     apr_hash_t *envattr;
     const char *userattr;

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -417,6 +417,35 @@ static const char *am_set_module_config_int_slot(cmd_parms *cmd,
     return ap_set_int_slot(cmd, am_get_mod_cfg(cmd->server), arg);
 }
 
+/* This function handles the MellonCookieSameSite configuration directive.
+ * This directive can be set to "lax" or "strict"
+ *
+ * Parameters:
+ *  cmd_parms *cmd       The command structure for this configuration
+ *                       directive.
+ *  void *struct_ptr     Pointer to the current directory configuration.
+ *  const char *arg      The string argument following this configuration
+ *                       directive in the configuraion file.
+ *
+ * Returns:
+ *  NULL on success or an error string if the argument is wrong.
+ */
+static const char *am_set_samesite_slot(cmd_parms *cmd,
+                                      void *struct_ptr,
+                                      const char *arg)
+{
+    am_dir_cfg_rec *d = (am_dir_cfg_rec *)struct_ptr;
+
+    if(!strcasecmp(arg, "lax")) {
+        d->cookie_samesite = am_samesite_lax;
+    } else if(!strcasecmp(arg, "strict")) {
+        d->cookie_samesite = am_samesite_strict;
+    } else {
+        return "The MellonCookieSameSite parameter must be 'lax' or 'strict'";
+    }
+
+    return NULL;
+}
 
 /* This function handles the MellonEnable configuration directive.
  * This directive can be set to "off", "info" or "auth".
@@ -449,6 +478,7 @@ static const char *am_set_enable_slot(cmd_parms *cmd,
 
     return NULL;
 }
+
 
 /* This function handles the MellonSecureCookie configuration directive.
  * This directive can be set to "on", "off", "secure" or "httponly".
@@ -1098,6 +1128,14 @@ const command_rec auth_mellon_commands[] = {
         "The path of the cookie which auth_mellon will set. Defaults to"
         " '/'."
         ),
+      AP_INIT_TAKE1(
+        "MellonCookieSameSite",
+        am_set_samesite_slot,
+        NULL,
+        OR_AUTHCFG,
+        "The SameSite value for the auth_mellon cookie. Defaults to"
+        " having no SameSite value. Accepts values of Lax or Strict."
+        ), 
     AP_INIT_TAKE1(
         "MellonUser",
         ap_set_string_slot,
@@ -1444,6 +1482,7 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->cond = apr_array_make(p, 0, sizeof(am_cond_t));
     dir->cookie_domain = NULL;
     dir->cookie_path = NULL;
+    dir->cookie_samesite = am_samesite_default;
     dir->envattr   = apr_hash_make(p);
     dir->userattr  = default_user_attribute;
     dir->idpattr  = NULL;
@@ -1582,6 +1621,10 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
     new_cfg->cookie_path = (add_cfg->cookie_path != NULL ?
                         add_cfg->cookie_path :
                         base_cfg->cookie_path);
+
+    new_cfg->cookie_samesite = (add_cfg->cookie_samesite != am_samesite_default ?
+                              add_cfg->cookie_samesite :
+                              base_cfg->cookie_samesite);
 
     new_cfg->cond = apr_array_copy(p,
                                    (!apr_is_empty_array(add_cfg->cond)) ?

--- a/auth_mellon_cookie.c
+++ b/auth_mellon_cookie.c
@@ -58,6 +58,7 @@ static const char *am_cookie_params(request_rec *r)
     int http_only_cookie;
     const char *cookie_domain = ap_get_server_name(r);
     const char *cookie_path = "/";
+    const char *cookie_samesite = "";
     am_dir_cfg_rec *cfg = am_get_dir_cfg(r);
 
     if (cfg->cookie_domain) {
@@ -68,14 +69,21 @@ static const char *am_cookie_params(request_rec *r)
         cookie_path = cfg->cookie_path;
     }
 
+    if (cfg->cookie_samesite == am_samesite_lax) {
+        cookie_samesite = "; SameSite=Lax";
+    } else if (cfg->cookie_samesite == am_samesite_strict) {
+        cookie_samesite = "; SameSite=Strict";
+    }
+
     secure_cookie = cfg->secure;
     http_only_cookie = cfg->http_only;
 
     return apr_psprintf(r->pool,
-                        "Version=1; Path=%s; Domain=%s%s%s;",
+                        "Version=1; Path=%s; Domain=%s%s%s%s;",
                         cookie_path, cookie_domain,
                         http_only_cookie ? "; HttpOnly" : "",
-                        secure_cookie ? "; secure" : "");
+                        secure_cookie ? "; secure" : "",
+                        cookie_samesite);
 }
 
 


### PR DESCRIPTION
MellonCookieSameSite allows control over the SameSite cookie
attribute. With this, authentication cookies can be protected
against CRFS type attacks.

The configuration directive can have values of Strict or Lax.
If not set, the attribute is not used on the authentication cookie.