### PR TITLE
Fix segmentation fault when the IdP returns an attribute without a Name.

### DIFF
--- a/auth_mellon_handler.c
+++ b/auth_mellon_handler.c
@@ -1551,6 +1551,12 @@ static int add_attributes(am_cache_entry_t *session, request_rec *r,
                 continue;
             }
 
+            if (attribute->Name == NULL) {
+                ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r,
+                              "SAML 2.0 attribute without name.");
+                continue;
+            }
+
             /* attribute->AttributeValue is a list of
              * LassoSaml2AttributeValue objects.
              */


### PR DESCRIPTION
The SAML 2.0 specification requires the name to be present, but we still
should not crash when it is missing. This patch fixes the crash by skipping
over attributes without a name.

Fixes issue #101.