### PR TITLE
Avoid trying to decode an empty string by crashing apache.

### DIFF
--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -745,6 +745,10 @@ int am_urldecode(char *data)
     if (data == NULL) {
         return HTTP_BAD_REQUEST;
     }
+    
+    if (strlen(data) == 0) {
+        return OK;
+    }
 
     ip = data;
     op = data;


### PR DESCRIPTION
Hello,

We've uncovered this issue when a repost is triggered and the form contains elements with no value (so empty string). The code was basically crashing apache with a SIGSEGV.

Here is a trace example from a code dump:
````
Core was generated by `/usr/sbin/apache2 -k start'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f4dae7a2630 in am_urldecode () from /usr/lib/apache2/modules/mod_auth_mellon.so
(gdb) where
#0  0x00007f4dae7a2630 in am_urldecode () from /usr/lib/apache2/modules/mod_auth_mellon.so
#1  0x00007f4dae7a47fa in am_post_mkform_urlencoded () from /usr/lib/apache2/modules/mod_auth_mellon.so
#2  0x00007f4dae7a8dc0 in am_handler () from /usr/lib/apache2/modules/mod_auth_mellon.so
````

Nicolas

