### PR TITLE
Add user_guide to distribution, use AC_DEFINE instead of CFLAGS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,3 @@
-
 # Source files. mod_auth_mellon.c must be the first file.
 SRC=mod_auth_mellon.c \
 	auth_mellon_cache.c \
@@ -9,6 +8,18 @@ SRC=mod_auth_mellon.c \
 	auth_mellon_util.c \
 	auth_mellon_session.c \
 	auth_mellon_httpclient.c
+
+# Documentation files
+USER_GUIDE_FILES=\
+	doc/user_guide/mellon_user_guide.adoc \
+	doc/user_guide/Guardfile \
+	doc/user_guide/README \
+	doc/user_guide/images/chrome_SAML_Chrome_Panel.png \
+	doc/user_guide/images/chrome_SAML_Chrome_Panel.svg \
+	doc/user_guide/images/saml-tracer.png \
+	doc/user_guide/images/saml-tracer.svg \
+	doc/user_guide/images/saml-web-sso.svg
+
 
 # Files to include when making a .tar.gz-file for distribution
 DISTFILES=$(SRC) \
@@ -22,8 +33,8 @@ DISTFILES=$(SRC) \
 	README \
 	ECP.rst \
 	COPYING \
-	NEWS
-
+	NEWS \
+	$(USER_GUIDE_FILES)
 
 all:	mod_auth_mellon.la
 

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -22,6 +22,8 @@
 #ifndef MOD_AUTH_MELLON_H
 #define MOD_AUTH_MELLON_H
 
+#include "config.h"
+
 #include <stdbool.h>
 
 #include <lasso/lasso.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
 AC_INIT([mod_auth_mellon],[0.13.1],[olav.morken@uninett.no])
+AC_CONFIG_HEADERS([config.h])
 
 # We require support for C99.
 AC_PROG_CC_C99
@@ -49,7 +50,7 @@ AC_ARG_ENABLE(
         [enable_diagnostics=no])
 
 AS_IF([test "x$enable_diagnostics" != xno],
-      [MELLON_CFLAGS="$MELLON_CFLAGS -DENABLE_DIAGNOSTICS"])
+      [AC_DEFINE([ENABLE_DIAGNOSTICS],[],[build with diagnostics])])
 
 # Replace any occurances of @APXS2@ with the value of $APXS2 in the Makefile.
 AC_SUBST(APXS2)
@@ -58,13 +59,17 @@ AC_SUBST(APXS2)
 PKG_CHECK_MODULES(LASSO, lasso)
 saved_LIBS=$LIBS; LIBS="$LIBS $LASSO_LIBS";
 AC_CHECK_LIB(lasso, lasso_server_new_from_buffers,
-	     LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_lasso_server_new_from_buffers")
+	     [AC_DEFINE([HAVE_lasso_server_new_from_buffers],[],
+             [lasso library exports lasso_server_new_from_buffers])])
 AC_CHECK_LIB(lasso, lasso_server_load_metadata,
-             LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_lasso_server_load_metadata")
+             [AC_DEFINE([HAVE_lasso_server_load_metadata],[],
+             [lasso library exports lasso_server_load_metadata])])
 AC_CHECK_LIB(lasso, lasso_profile_set_signature_verify_hint,
-             LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_lasso_profile_set_signature_verify_hint")
+             [AC_DEFINE([HAVE_lasso_profile_set_signature_verify_hint],[],
+             [lasso library exports lasso_profile_set_signature_verify_hint])])
 AC_CHECK_LIB(lasso, lasso_ecp_request_new,
-             LASSO_CFLAGS="$LASSO_CFLAGS -DHAVE_ECP")
+             [AC_DEFINE([HAVE_ECP],[],
+             [lasso library supports ECP profile])])
 LIBS=$saved_LIBS;
 AC_SUBST(LASSO_CFLAGS)
 AC_SUBST(LASSO_LIBS)


### PR DESCRIPTION
This patch corrects a few minor autotool issues.

The user_guide was recently added but that commit failed to include
adding the new documentation to the tarball, Makefile.in was augmented
to include the new files to the list of distribution files.

Formerly the #defines generated by configure were passed to the
compiler on the command line in various CFLAGS values. Although that
works the more -Dxxx that configure generates the longer the compile
command becomes and it starts to get unreadable and possibly exceed
command line length. A more common practice with autotools is to
employ autoheader whereby configure generates a file typically called
config.h which then is included by the C files. The contents of
config.h contains the #defines as generated by configure. configure.ac
was updated to utilize the AC_DEFINE in lieu of adding -Dxxx to CFLAGS
and to generate and output config.h.

Note: autogen.sh needs to be re-run to pick up these changes so that
the configure included in the tarball contains the updated version.

Signed-off-by: John Dennis <jdennis@redhat.com>