### PR TITLE
Add missing config.h.in to distribution files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,6 +23,7 @@ USER_GUIDE_FILES=\
 
 # Files to include when making a .tar.gz-file for distribution
 DISTFILES=$(SRC) \
+	config.h.in \
 	auth_mellon.h \
 	auth_mellon_compat.h \
 	lasso_compat.h \


### PR DESCRIPTION
The file config.h.in was erroneously omitted in the list of files
to include in the distribution.

config.h.in is (re)generated when autoheader is run which is
run automatically when autogen.sh is run.

Signed-off-by: John Dennis <jdennis@redhat.com>