### PR TITLE
Fix conditional build of auth_mellon_diagnostics.c

### DIFF
--- a/auth_mellon_diagnostics.c
+++ b/auth_mellon_diagnostics.c
@@ -1,6 +1,6 @@
-#ifdef ENABLE_DIAGNOSTICS
-
 #include "auth_mellon.h"
+
+#ifdef ENABLE_DIAGNOSTICS
 
 #if APR_HAVE_UNISTD_H
 #include <unistd.h>


### PR DESCRIPTION
Commit de853e15 introduced using config.h to define optional build
parameters instead of putting them on the compile command
line. Unfortunately that broke the compilation of
auth_mellon_diagostics.c.

We used to have this:

ifdef ENABLE_DIAGNOSTICS
include "auth_mellon.h"

but the flag ENABLE_DIAGNOSTICS is now defined by including
auth_mellon.h (which includes config.h) hence it would be impossible
for the ENABLE_DIAGNOSTICS to be defined during compilation.

The solution is simple, just reverse the order of the two lines such
that the defines are seen before the #ifdef conditional.

Signed-off-by: John Dennis <jdennis@redhat.com>