### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM httpd:alpine AS builder
+RUN apk --update add \
+  autoconf \
+  automake \
+  curl-dev \
+  g++ \
+  glib-dev \
+  libtool \
+  libxml2-dev \
+  make \
+  perl-dev \
+  py-six \
+  python \
+  xmlsec-dev \
+  zlib-dev
+
+# Install xmlsec
+RUN cd /tmp && \
+  wget http://www.aleksey.com/xmlsec/download/xmlsec1-1.2.25.tar.gz && \
+  tar xzf xmlsec1-1.2.25.tar.gz && \
+  cd xmlsec1-1.2.25 && \
+  ./configure --enable-soap && \
+  make && \
+  make install
+
+# Install lasso
+RUN cd /tmp && \
+  wget https://dev.entrouvert.org/releases/lasso/lasso-2.5.1.tar.gz && \
+  tar zxf lasso-2.5.1.tar.gz && \
+  cd lasso-2.5.1 && \
+  ./configure && \
+  make && \
+  make install
+
+# Install mod_auth_mellon
+COPY . /tmp/mod_auth_mellon
+RUN cd /tmp/mod_auth_mellon && \
+  aclocal && \
+  autoheader && \
+  autoconf && \
+  ./configure --with-apxs2=/usr/local/apache2/bin/apxs && \
+  make && \
+  make install
+
+FROM httpd:alpine
+RUN apk --update add glib curl libxslt libltdl
+COPY --from=builder /usr/local/apache2/modules/mod_auth_mellon.so /usr/local/apache2/modules/mod_auth_mellon.so
+COPY --from=builder /usr/local/lib/liblasso* /usr/local/lib/
+COPY --from=builder /usr/local/lib/libxmlsec1* /usr/local/lib/


### PR DESCRIPTION
I put this together for myself and thought I'd share in case it is wanted. I'm not sure what the maintainer's level of familiarity is with docker or how much I should explain what's happening here so I'll start with a quick explanation and we can talk in more detail here if there's interest.

This Dockerfile is built on top of httpd:alpine, which is the alpine version of the Docker community's "official" httpd image (https://github.com/docker-library/httpd). This Dockerfile can be used to build new httpd images that include mod_auth_mellon, compiled and ready to run. In fact, my intention was for that to be the only difference between these images, and the ones produced upstream.

What I'm envisioning is a dockerhub integration which is easy to add from the dockerhub web service which could automatically build and publish new docker images on new master commits here and/or new release tags.

I'm happy to spend a bit more effort on this if there's interest, otherwise I'll be on my merry way using this for my own purposes.