### PR TITLE
Exclude ':PORT' from  when endopint URL contains port number.

### DIFF
--- a/mellon_create_metadata.sh
+++ b/mellon_create_metadata.sh
@@ -33,7 +33,7 @@ if ! echo "$BASEURL" | grep -q '^https\?://'; then
     exit 1
 fi
 
-HOST="$(echo "$BASEURL" | sed 's#^[a-z]*://\([^/]*\).*#\1#')"
+HOST="$(echo "$BASEURL" | sed 's#^[a-z]*://\([^:/]*\).*#\1#')"
 BASEURL="$(echo "$BASEURL" | sed 's#/$##')"
 
 OUTFILE="$(echo "$ENTITYID" | sed 's/[^0-9A-Za-z.]/_/g' | sed 's/__*/_/g')"


### PR DESCRIPTION
$HOST should not contain port number even when endpoint URL has ':PORT' subcomponent.