### PR TITLE
added some additional cli args for metadata script

### DIFF
--- a/mellon_create_metadata.sh
+++ b/mellon_create_metadata.sh
@@ -1,28 +1,70 @@
 #!/usr/bin/env bash
 set -e
 
-PROG="$(basename "$0")"
+print_help() {
+    cat << EOF
 
-printUsage() {
-    echo "Usage: $PROG ENTITY-ID ENDPOINT-URL"
-    echo ""
-    echo "Example:"
-    echo "  $PROG urn:someservice https://sp.example.org/mellon"
-    echo ""
+    Usage: ${0##*/} [-h] [-k KEYFILE] [-c CERTFILE] [-m METADATAFILE] [-e ENTITYID] [-b BASEURL]
+
+    Example:
+        ${0##*/} -k keystone_fed.key -c keystone_fed.cert -m mellon_metadata.xml \\
+          -e https://aio.mycloud.com:5000/v3/mellon/metadata -b https://aio.mycloud.com:5000/v3/mellon
+
+    Output:
+        3 Files will be created in the current working directory
+        1. keystone_fed.cert
+        2. keystone_fed.key
+        3. mellon_metadata.xml
+
+    Example:
+        ${0##*/} -h
+
+    Output:
+        This help message
+EOF
 }
 
-if [ "$#" -lt 2 ]; then
-    printUsage
+while getopts ":k:c:m:e:b:" opt; do
+    case $opt in
+      k)
+        KEYFILE=$OPTARG
+        ;;
+      c)
+        CERTFILE=$OPTARG
+        ;;
+      m)
+        METADATAFILE=$OPTARG
+        ;;
+      e)
+        ENTITYID=$OPTARG
+        ;;
+      b)
+        BASEURL=$OPTARG
+        ;;
+      h)
+        print_help
+        exit 0
+        ;;
+      *)
+        print_help >&2
+        exit 1
+        ;;
+    esac
+done
+
+PROG="$(basename "$0")"
+
+
+if [ "$#" -lt 5 ]; then
+    print_help
     exit 1
 fi
 
-ENTITYID="$1"
 if [ -z "$ENTITYID" ]; then
     echo "$PROG: An entity ID is required." >&2
     exit 1
 fi
 
-BASEURL="$2"
 if [ -z "$BASEURL" ]; then
     echo "$PROG: The URL to the MellonEndpointPath is required." >&2
     exit 1
@@ -33,19 +75,21 @@ if ! echo "$BASEURL" | grep -q '^https\?://'; then
     exit 1
 fi
 
-HOST="$(echo "$BASEURL" | sed 's#^[a-z]*://\([^:/]*\).*#\1#')"
+HOST="$(echo "$BASEURL" | sed 's#^[a-z]*://\([^/]*\).*#\1#')"
 BASEURL="$(echo "$BASEURL" | sed 's#/$##')"
 
-OUTFILE="$(echo "$ENTITYID" | sed 's/[^0-9A-Za-z.]/_/g' | sed 's/__*/_/g')"
 echo "Output files:"
-echo "Private key:               $OUTFILE.key"
-echo "Certificate:               $OUTFILE.cert"
-echo "Metadata:                  $OUTFILE.xml"
-echo "Host:                      $HOST"
+echo "Private key:                              ${KEYFILE}"
+echo "Certificate:                              ${CERTFILE}"
+echo "Metadata:                                 ${METADATAFILE}"
+echo "Host:                                     ${HOST}"
 echo
 echo "Endpoints:"
-echo "SingleLogoutService:       $BASEURL/logout"
-echo "AssertionConsumerService:  $BASEURL/postResponse"
+echo "SingleLogoutService (SOAP):               ${BASEURL}/logout"
+echo "SingleLogoutService (HTTP-Redirect):      ${BASEURL}/logout"
+echo "AssertionConsumerService (HTTP-POST):     ${BASEURL}/postResponse"
+echo "AssertionConsumerService (HTTP-Artifact): ${BASEURL}/artifactResponse"
+echo "AssertionConsumerService (PAOS):          ${BASEURL}/paosResponse"
 echo
 
 # No files should not be readable by the rest of the world.
@@ -65,28 +109,59 @@ policy             = policy_anything
 commonName         = $HOST
 EOF
 
-openssl req -utf8 -batch -config "$TEMPLATEFILE" -new -x509 -days 3652 -nodes -out "$OUTFILE.cert" -keyout "$OUTFILE.key" 2>/dev/null
+openssl req -utf8 -batch -config "$TEMPLATEFILE" -new -x509 -days 3652 -nodes -out "${CERTFILE}" -keyout "${KEYFILE}" 2>/dev/null
 
 rm -f "$TEMPLATEFILE"
 
-CERT="$(grep -v '^-----' "$OUTFILE.cert")"
+CERT="$(grep -v '^-----' "${CERTFILE}")"
 
-cat >"$OUTFILE.xml" <<EOF
-<EntityDescriptor entityID="$ENTITYID" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-    <KeyDescriptor use="signing">
-      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-        <ds:X509Data>
-          <ds:X509Certificate>$CERT</ds:X509Certificate>
-        </ds:X509Data>
-      </ds:KeyInfo>
-    </KeyDescriptor>
-    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="$BASEURL/logout"/>
-    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="$BASEURL/postResponse" index="0"/>
-  </SPSSODescriptor>
+cat >"${METADATAFILE}" <<EOF
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EntityDescriptor
+ entityID="${ENTITYID}"
+ xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+ <SPSSODescriptor
+   AuthnRequestsSigned="true"
+   WantAssertionsSigned="true"
+   protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+   <KeyDescriptor use="signing">
+     <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+       <ds:X509Data>
+         <ds:X509Certificate>$CERT</ds:X509Certificate>
+       </ds:X509Data>
+     </ds:KeyInfo>
+   </KeyDescriptor>
+   <KeyDescriptor use="encryption">
+     <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+       <ds:X509Data>
+         <ds:X509Certificate>$CERT</ds:X509Certificate>
+       </ds:X509Data>
+     </ds:KeyInfo>
+   </KeyDescriptor>
+   <SingleLogoutService
+     Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+     Location="$BASEURL/logout" />
+   <SingleLogoutService
+     Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+     Location="$BASEURL/logout" />
+   <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+   <AssertionConsumerService
+     index="0"
+     isDefault="true"
+     Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+     Location="$BASEURL/postResponse" />
+   <AssertionConsumerService
+     index="1"
+     Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"
+     Location="$BASEURL/artifactResponse" />
+   <AssertionConsumerService
+     index="2"
+     Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS"
+     Location="$BASEURL/paosResponse" />
+ </SPSSODescriptor>
 </EntityDescriptor>
 EOF
 
 umask 0777
-chmod go+r "$OUTFILE.xml"
-chmod go+r "$OUTFILE.cert"
+chmod go+r "${METADATAFILE}"
+chmod go+r "${CERTFILE}"


### PR DESCRIPTION
Added some additional cli args to the metadata creation sctipt.
These allow you to set the following:

  * keyfile name
  * certfile name
  * metadata file name
  * entity id
  * baseurl

The metadata file it makes by default was also expanded to add
a few common options used when setting up for use with OpenStack
Keystone.