### PR TITLE
Add ability to set cookie expiry time

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ MellonDiagnosticsEnable Off
         # Default: /
         MellonCookiePath /
 
+        # MellonCookieExpires seconds into the future the cookie will expire
+        # the date will be now() + MellonCookieExpires
+        # Default: Unset (Browser Session)
+        # MellonCookieExpires 86400
+
         # MellonCookieSameSite allows control over the SameSite value used
         # for the authentication cookie.
         # The setting accepts values of "Strict" or "Lax"

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -268,6 +268,9 @@ typedef struct am_dir_cfg_rec {
     /* Maximum number of seconds a session is valid for. */
     int session_length;
 
+    /* When cookie expires */
+    int cookie_expires;
+
     /* No cookie error page. */
     const char *no_cookie_error_page;
 

--- a/auth_mellon_config.c
+++ b/auth_mellon_config.c
@@ -1427,6 +1427,14 @@ const command_rec auth_mellon_commands[] = {
         " to 86400 seconds (1 day)."
         ),
     AP_INIT_TAKE1(
+        "MellonCookieExpires",
+        ap_set_int_slot,
+        (void *)APR_OFFSETOF(am_dir_cfg_rec, cookie_expires),
+        OR_AUTHCFG,
+        "Maximum number of seconds a cookie will be valid for"
+        "Defaults to browser session"
+        ),
+    AP_INIT_TAKE1(
         "MellonNoCookieErrorPage",
         ap_set_string_slot,
         (void *)APR_OFFSETOF(am_dir_cfg_rec, no_cookie_error_page),
@@ -1723,6 +1731,7 @@ void *auth_mellon_dir_config(apr_pool_t *p, char *d)
     dir->endpoint_path = default_endpoint_path;
 
     dir->session_length = -1; /* -1 means use default. */
+    dir->cookie_expires = -1; /* -1 means use default. */
 
     dir->no_cookie_error_page = NULL;
     dir->no_success_error_page = NULL;
@@ -1896,6 +1905,10 @@ void *auth_mellon_dir_merge(apr_pool_t *p, void *base, void *add)
     new_cfg->session_length = (add_cfg->session_length != -1 ?
                                add_cfg->session_length :
                                base_cfg->session_length);
+
+    new_cfg->cookie_expires = (add_cfg->cookie_expires != -1 ?
+                               add_cfg->cookie_expires :
+                               base_cfg->cookie_expires);
 
     new_cfg->no_cookie_error_page = (add_cfg->no_cookie_error_page != NULL ?
                                      add_cfg->no_cookie_error_page :

--- a/doc/user_guide/mellon_user_guide.adoc
+++ b/doc/user_guide/mellon_user_guide.adoc
@@ -1948,8 +1948,6 @@ validity period for a Mellon session is the lesser of the
 `MellonSessionLength` or the optional IdP `SessionNotOnOrAfter`
 attribute if the IdP supplied it.
 
-
-
 === Mellon Cookie [[mellon_cookie]]
 
 <<mellon_session>> information is communicated via a cookie. The
@@ -1976,6 +1974,10 @@ ID and attempts to look-up that session using that ID. If the session
 is found and it remains valid, Mellon immediately grants access. A
 Mellon session will expire, see <<mellon_session>> for information
 concerning session lifetime.
+
+MellonCookieExpires can change how long the cookie lives.  By default cookie
+lives as long as browser session, but using MellonCookieExpires directive
+it's possible to set cookie expiry that many seconds into the future
 
 == Working with SAML attributes and exporting values to web apps
 


### PR DESCRIPTION
Mellon doesn't set the cookie expiry time thereby it defaults to browser session, this lets the time be set in seconds in the future from now.  