### PR TITLE
Make the environment variable prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,11 @@ MellonDiagnosticsEnable Off
         # Default. None set.
         MellonSetEnvNoPrefix "DISPLAY_NAME" "displayName"
 
+        # MellonEnvPrefix changes the string the variables passed from the
+        # IdP are prefixed with.
+        # Default: MELLON_
+        MellonEnvPrefix "NOLLEM_"
+
         # MellonMergeEnvVars merges multiple values of environment variables
         # set using MellonSetEnv into single variable:
         # ie: MYENV_VAR => val1;val2;val3 instead of default behaviour of:

--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -237,6 +237,7 @@ typedef struct am_dir_cfg_rec {
     am_samesite_t cookie_samesite;
     apr_array_header_t *cond;
     apr_hash_t *envattr;
+    const char *env_prefix;
     const char *userattr;
     const char *idpattr;
     LassoSignatureMethod signature_method;

--- a/auth_mellon_cache.c
+++ b/auth_mellon_cache.c
@@ -589,7 +589,7 @@ void am_cache_env_populate(request_rec *r, am_cache_entry_t *t)
      */
     for(i = 0; i < t->size; ++i) {
         varname = am_cache_entry_get_string(t, &t->env[i].varname);
-        varname_prefix = "MELLON_";
+        varname_prefix = d->env_prefix;
 
         /* Check if we should map this name into another name. */
         env_varname_conf = (am_envattr_conf_t *)apr_hash_get(

--- a/auth_mellon_diagnostics.c
+++ b/auth_mellon_diagnostics.c
@@ -442,6 +442,9 @@ am_diag_log_dir_cfg(request_rec *r, int level, am_dir_cfg_rec *cfg,
                     "%sMellonCookieSameSite (cookie_samesite): %s\n",
                     indent(level+1),
                     am_diag_samesite_str(r, cfg->cookie_samesite));
+    apr_file_printf(diag_cfg->fd,
+                    "%sMellonEnvPrefix (env_prefix): %s\n",
+                    indent(level+1), cfg->env_prefix);
 
     apr_file_printf(diag_cfg->fd,
                     "%sMellonCond (cond): %d items\n",
@@ -466,7 +469,7 @@ am_diag_log_dir_cfg(request_rec *r, int level, am_dir_cfg_rec *cfg,
         apr_hash_this(hash_item, (void *)&key, NULL, (void *)&envattr_conf);
 
         if (envattr_conf->prefixed) {
-            name = apr_pstrcat(r->pool, "MELLON_",
+            name = apr_pstrcat(r->pool, cfg->env_prefix,
                                envattr_conf->name, NULL);
         } else {
             name = envattr_conf->name;

--- a/doc/user_guide/mellon_user_guide.adoc
+++ b/doc/user_guide/mellon_user_guide.adoc
@@ -2007,11 +2007,13 @@ attributes.
   assertion to a name of your choosing when it is placed in the Apache
   environment. This is controlled by `MellonSetEnv` and
   `MellonSetEnvNoPrefix` directives.  The distinction
-  is `MellonSetEnv` always prepends the `MELLON_` prefix to the
+  is `MellonSetEnv` always prepends a prefix to the
   environment variable name to help to prevent name collisions. The
+  prefix defaults to `MELLON_` and can be configured using the
+  `MellonEnvPrefix` configuration option. The
   `MellonSetEnvNoPrefix` directive also remaps the assertion name to a
   name of your choosing but it omits prepending the environment
-  variable name with `MELLON_`. See <<map_assertion_attr_name>>
+  variable name with the prefix. See <<map_assertion_attr_name>>
 
 Using the <<assertion_response,assertion example>> Mellon places these
 environment variables in the Apache environment. See
@@ -2096,10 +2098,12 @@ and `MellonSetEnvNoPrefix` directives. These allow you to rename an
 assertion attribute to a name of your choosing. The `MellonSetEnv`
 directive follows the same convention as all other assertion
 attributes added by Mellon in that it always prefixes the environment
-variable name with `MELLON_` to help avoid name collisions in the
+variable name with a configurable prefix, which defaults to `MELLON_` to help avoid name collisions in the
 Apache environment. However sometimes you do not want the `MELLON_`
-prefix added and instead you want to use exactly the environment
-variable name as specified., `MellonSetEnvNoPrefix` serves this role.
+prefix added. In case you simply want the variables prefixed with
+a different string, use the `MellonEnvPrefix` configuration option. If,
+instead you want to use exactly the environment variable name as specified.,
+`MellonSetEnvNoPrefix` serves this role.
 
 To illustrate let's look at an example. Suppose your web app is
 expecting an attribute which is the user's last name, specifically it
@@ -2116,6 +2120,15 @@ MellonSetEnvNoPrefix REMOTE_USER_LASTNAME sn
 
 Also see <<set_remote_user>> for an example of setting the `REMOTE_USER`
 environment variable using `MellonSetEnvNoPrefix`.
+
+The `MellonEnvPrefix` variable might be useful e.g. if you
+are migrating from a different SP which used its own prefix
+for the variables passed by the IdP. For example, to prefix
+all variables with `NOLLEM_` you would use:
+
+----
+MellonEnvPrefix NOLLEM_
+----
 
 If you recieved an attribute-map.xml from your IDP that uses the
 `urn:mace:shibboleth:2.0:attribute-map` namespace, it can be converted


### PR DESCRIPTION
mellon passes on every attribute received in a SAML assertion as an
Apache variable. By default, the variable is prefixed with "MELLON_".

In some cases, for example when migrating from a different SP to mellon
it might be beneficial to change the prefix. And while using
MellonSetEnvNoPrefix is an option as well, the MellonSetEnvNoPrefix has
to be specified for each variable independently.