### PR TITLE
Fix implicit function declaration: rindex on Solaris

### DIFF
--- a/auth_mellon.h
+++ b/auth_mellon.h
@@ -25,6 +25,7 @@
 #include "config.h"
 
 #include <stdbool.h>
+#include <strings.h>
 
 #include <lasso/lasso.h>
 #include <lasso/xml/saml-2.0/samlp2_authn_request.h>


### PR DESCRIPTION
Compilation on reports warning:

"auth_mellon_diagnostics.c", line 188: warning: implicit function declaration: rindex
"auth_mellon_diagnostics.c", line 188: warning: improper pointer/integer combination: op "="

And binary dumps core, because rindex() is assumed to be integer type, so
compiler sign extends its return value and then uses the number as pointer:

am_diag_cond_str+0x154:      call   -0x1e119 <PLT=libc.so.1`rindex>
am_diag_cond_str+0x159:      movslq %eax,%rax
am_diag_cond_str+0x15c:      testq  %rax,%rax
am_diag_cond_str+0x15f:      je     +0x7     <am_diag_cond_str+0x168>
am_diag_cond_str+0x161:      movb   $0x5d,(%rax)  <- SIGSEGV

Fixes issue #207.