### PR TITLE
Fix: size not written to error_log

### DIFF
--- a/auth_mellon_cache.c
+++ b/auth_mellon_cache.c
@@ -235,7 +235,8 @@ static int am_cache_entry_store_string(am_cache_entry_t *entry,
 
     if (am_cache_entry_pool_left(entry) < str_len) {
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
-                     "apr_cache_entry_store_string() asked %zd available: %zd. "
+                     "apr_cache_entry_store_string() asked %" APR_SIZE_T_FMT 
+                     " available: %" APR_SIZE_T_FMT ". "
                      "It may be a good idea to increase MellonCacheEntrySize.",
                      str_len, am_cache_entry_pool_left(entry));
         return HTTP_INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
# Description
If MellonCacheEntrySize is not enough, the error log will be written as follows:

```
[Mon Jul 29 04:23:09.574050 2019] [auth_mellon:error] [pid 9] apr_cache_entry_store_string() 
asked %zd available: %zd. It may be a good idea to increase MellonCacheEntrySize.
```

# Analysis 
ap_log_error format is incorrect.

```
        ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
                     "apr_cache_entry_store_string() asked %zd available: %zd. "
                     "It may be a good idea to increase MellonCacheEntrySize.",
                     str_len, am_cache_entry_pool_left(entry));

```