### PR TITLE
Fix build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: c
 env:
   - APACHE_PKG=apache2-prefork-dev


### PR DESCRIPTION
Travis CI recently changed the default distribution from Ubuntu 14.04
(Trusty) to Ubuntu 18.04 (Xenial):

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

This was a slow rollout, and does not appear to have reached this
project until the last couple of weeks.

This patch simply pins the distribution used for tests to Ubuntu 14.04
(Trusty), to ensure that we always use a consistent build environment.

A later patch will update it to a more recent distribution.