### PR TITLE
Switch to Ubuntu 18.04 (Bionic) for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
-dist: trusty
+dist: bionic
 language: c
-env:
-  - APACHE_PKG=apache2-prefork-dev
-  - APACHE_PKG=apache2-threaded-dev
 install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq "$APACHE_PKG" libglib2.0-dev liblasso3-dev libssl-dev
+  - sudo apt-get install -qq apache2-dev libglib2.0-dev liblasso3-dev libssl-dev
 script: ./autogen.sh && ./configure CFLAGS=-Werror && make && make distfile


### PR DESCRIPTION
This patch updates the Travis CI build configuration to use Ubuntu
18.04 (Bionic).

Since Ubuntu 18.04 no longer has separate packages for the different
Apache Multi-Processing Modules, we no longer need to build with both
apache2-prefork-dev and apache2-threaded-dev. We simply need to build
against apache2-dev.