### PR TITLE
Remove backslash check as it is no longer required

### DIFF
--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -116,6 +116,10 @@ int am_validate_redirect_url(request_rec *r, const char *url)
 
     /* Sanity check of the scheme of the domain. We only allow http and https. */
     if (uri.scheme) {
+	/* http and https schemes without hostname are invalid. */
+        if (!uri.hostname) {
+            return HTTP_BAD_REQUEST; 
+    	}
         if (strcasecmp(uri.scheme, "http")
             && strcasecmp(uri.scheme, "https")) {
             AM_LOG_RERROR(APLOG_MARK, APLOG_ERR, 0, r,

--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -931,13 +931,6 @@ int am_check_url(request_rec *r, const char *url)
                           "Control character detected in URL.");
             return HTTP_BAD_REQUEST;
         }
-        if (*i == '\\') {
-            /* Reject backslash character, as it can be used to bypass
-             * redirect URL validation. */
-            AM_LOG_RERROR(APLOG_MARK, APLOG_ERR, HTTP_BAD_REQUEST, r,
-                          "Backslash character detected in URL.");
-            return HTTP_BAD_REQUEST;
-        }
     }
 
     return OK;


### PR DESCRIPTION
Remove this check https://github.com/Uninett/mod_auth_mellon/commit/62041428a32de402e0be6ba45fe12df6a83bedb8, because it is covered by fix of CVE-2019-13038 https://github.com/Uninett/mod_auth_mellon/pull/220